### PR TITLE
Task: Add backgroundColor prop to header and footer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formidable-landers",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Reusable components for Formidable's marketing sites",
   "main": "lib/index.js",
   "scripts": {

--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -10,9 +10,9 @@ class Footer extends React.Component {
         listStyle: "none",
         margin: "1rem 0 0 0",
         padding: "3rem 0.5rem",
-        backgroundColor: "#ebe3db",
+        backgroundColor: this.props.backgroundColor,
         textAlign: "center",
-        borderBottom: "1px solid rgba(35, 31, 32, 0.02)"
+        borderTop: "1px solid rgba(35, 31, 32, 0.02)"
       },
       text: {
         display: "block"
@@ -48,10 +48,12 @@ class Footer extends React.Component {
 }
 
 Footer.propTypes = {
+  backgroundColor: React.PropTypes.string,
   styleOverrides: React.PropTypes.object
 };
 
 Footer.defaultProps = {
+  backgroundColor: "#ebe3db",
   styleOverrides: null
 };
 

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -39,14 +39,14 @@ class Header extends React.Component {
 
 Header.propTypes = {
   backgroundColor: React.PropTypes.string,
-  styleOverrides: React.PropTypes.object,
-  children: React.PropTypes.string
+  children: React.PropTypes.string,
+  styleOverrides: React.PropTypes.object
 };
 
 Header.defaultProps = {
   backgroundColor: "#ebe3db",
-  styleOverrides: null,
-  children: "Need React.js consulting? Let’s talk."
+  children: "Need React.js consulting? Let’s talk.",
+  styleOverrides: null
 };
 
 export default Header;

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -30,7 +30,7 @@ class Header extends React.Component {
           this.props.styleOverrides && headerStyles.styleOverrides
         ]}>
         <a href="mailto:hello@formidable.com" style={{margin: "0 auto", lineHeight: 1}}>
-          {this.props.text}
+          {this.props.children}
         </a>
       </header>
     );
@@ -40,13 +40,13 @@ class Header extends React.Component {
 Header.propTypes = {
   backgroundColor: React.PropTypes.string,
   styleOverrides: React.PropTypes.object,
-  text: React.PropTypes.string
+  children: React.PropTypes.string
 };
 
 Header.defaultProps = {
   backgroundColor: "#ebe3db",
   styleOverrides: null,
-  text: "Need React.js consulting? Let’s talk."
+  children: "Need React.js consulting? Let’s talk."
 };
 
 export default Header;

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -39,7 +39,7 @@ class Header extends React.Component {
 
 Header.propTypes = {
   backgroundColor: React.PropTypes.string,
-  children: React.PropTypes.string,
+  children: React.PropTypes.node,
   styleOverrides: React.PropTypes.object
 };
 

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -13,7 +13,7 @@ class Header extends React.Component {
         justifyContent: "space-between",
         margin: 0,
         padding: "1rem 0.5rem",
-        backgroundColor: "#ebe3db",
+        backgroundColor: this.props.backgroundColor,
         textAlign: "center",
         borderBottom: "1px solid rgba(35, 31, 32, 0.02)"
       },
@@ -38,10 +38,12 @@ class Header extends React.Component {
 }
 
 Header.propTypes = {
+  backgroundColor: React.PropTypes.string,
   styleOverrides: React.PropTypes.object
 };
 
 Header.defaultProps = {
+  backgroundColor: "#ebe3db",
   styleOverrides: null
 };
 

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -38,23 +38,15 @@ class Header extends React.Component {
 }
 
 Header.propTypes = {
-<<<<<<< HEAD
   backgroundColor: React.PropTypes.string,
-  styleOverrides: React.PropTypes.object
-};
-
-Header.defaultProps = {
-  backgroundColor: "#ebe3db",
-  styleOverrides: null
-=======
   styleOverrides: React.PropTypes.object,
   text: React.PropTypes.string
 };
 
 Header.defaultProps = {
+  backgroundColor: "#ebe3db",
   styleOverrides: null,
   text: "Need React.js consulting? Let’s talk."
->>>>>>> master
 };
 
 export default Header;

--- a/src/themes/victory.js
+++ b/src/themes/victory.js
@@ -323,6 +323,9 @@ export default {
     fontFamily: settings.serif,
     fontWeight: "normal"
   },
+  ".Prop td:first-child": {
+    maxWidth: "30em"
+  },
   ".Prop-name": {
     fontFamily: settings.monospace
   },


### PR DESCRIPTION
- Resolves https://github.com/FormidableLabs/formidable-landers/issues/2
- Add `backgroundColor` prop for both header and footer 
- Add a `max-width` style so the props name column doesn't get too wide: 
<img width="1199" alt="screen shot 2016-01-04 at 9 47 43 am" src="https://cloud.githubusercontent.com/assets/768965/12096153/3a87a9c8-b2c8-11e5-9a42-9ae3e9c45a3a.png">
- Also converted `this.props.text` to `this.props.children` but this is a personal preference and willing to revert 

/cc @david-davidson 