### PR TITLE
Task: Add support for children props in Footer 

### DIFF
--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -42,6 +42,9 @@ class Footer extends React.Component {
         <span style={[footerStyles.text]}>
           P.S. <a href="http://formidable.com/studio/" style={{lineHeight: 1}}>We’re hiring</a>.
         </span>
+        <span style={[footerStyles.text]}>
+          {this.props.children}
+        </span>
       </footer>
     );
   }

--- a/src/themes/victory.js
+++ b/src/themes/victory.js
@@ -121,12 +121,12 @@ export default {
     color: settings.navy,
     fontWeight: 700,
     textDecoration: "none",
-    boxShadow: "inset 0 -0.05em 0 " + settings.sand,
+    boxShadow: "inset 0 -1px 0 " + settings.sand,
     transition: "color 0.2s ease, box-shadow 0.5s ease"
   },
   "a:hover, a:focus": {
     color: settings.red,
-    boxShadow: "inset 0 -0.05em 0 " + settings.paleRed,
+    boxShadow: "inset 0 -1px 0 " + settings.palestRed,
     transition: "color 0.2s ease, box-shadow 0.5s ease"
   },
   ".Link--unstyled": {


### PR DESCRIPTION
- Add `{this.props.children}` in footer.jsx
- Change to `px` units so the links look the same cross-browser

/cc @david-davidson 