### PR TITLE
Task: Add props for overriding link styles in Header and Footer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formidable-landers",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Reusable components for Formidable's marketing sites",
   "main": "lib/index.js",
   "scripts": {

--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -3,7 +3,6 @@ import Radium from "radium";
 
 @Radium
 class Footer extends React.Component {
-
   getFooterStyles() {
     return {
       base: {
@@ -16,6 +15,18 @@ class Footer extends React.Component {
       },
       text: {
         display: "block"
+      },
+      linkLogo: {
+        display: "block",
+        boxShadow: "none",
+        border: "none",
+        textDecoration: "none",
+        ":hover": {
+          backgroundColor: "transparent",
+          boxShadow: "none",
+          border: "none",
+          textDecoration: "none"
+        }
       },
       styleOverrides: this.props.styleOverrides
     };
@@ -33,7 +44,7 @@ class Footer extends React.Component {
           Made with love in Seattle by
         </span>
         <span style={[footerStyles.text]}>
-          <a href="http://formidable.com/" style={{display: "block", boxShadow: "none"}}>
+          <a href="http://formidable.com/" style={footerStyles.linkLogo}>
             <img width="300px" height="100px"
               src="static/logo-formidable-black.svg"
               alt="Formidable" />

--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -66,15 +66,11 @@ class Footer extends React.Component {
 }
 
 Footer.propTypes = {
-  backgroundColor: React.PropTypes.string,
-  linkStyles: React.PropTypes.object,
-  styleOverrides: React.PropTypes.object
+  backgroundColor: React.PropTypes.string
 };
 
 Footer.defaultProps = {
-  backgroundColor: "#ebe3db",
-  linkStyles: null,
-  styleOverrides: null
+  backgroundColor: "#ebe3db"
 };
 
 export default Footer;

--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -28,6 +28,7 @@ class Footer extends React.Component {
           textDecoration: "none"
         }
       },
+      linkStyles: this.props.linkStyles,
       styleOverrides: this.props.styleOverrides
     };
   }
@@ -51,7 +52,10 @@ class Footer extends React.Component {
           </a>
         </span>
         <span style={[footerStyles.text]}>
-          P.S. <a href="http://formidable.com/studio/" style={{lineHeight: 1}}>We’re hiring</a>.
+          P.S. <a href="http://formidable.com/studio/"
+            style={[this.props.linkStyles && footerStyles.linkStyles]}>
+            We’re hiring
+          </a>.
         </span>
         <span style={[footerStyles.text]}>
           {this.props.children}
@@ -63,11 +67,13 @@ class Footer extends React.Component {
 
 Footer.propTypes = {
   backgroundColor: React.PropTypes.string,
+  linkStyles: React.PropTypes.object,
   styleOverrides: React.PropTypes.object
 };
 
 Footer.defaultProps = {
   backgroundColor: "#ebe3db",
+  linkStyles: null,
   styleOverrides: null
 };
 

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -6,7 +6,10 @@ class Header extends React.Component {
   getHeaderStyles() {
     return {
       base: {
-        display: "block",
+        display: "flex",
+        flexWrap: "wrap",
+        listStyle: "none",
+        justifyContent: "space-between",
         margin: 0,
         padding: "1rem 0.5rem",
         backgroundColor: this.props.backgroundColor,
@@ -30,14 +33,16 @@ class Header extends React.Component {
           headerStyles.base,
           this.props.styleOverrides && headerStyles.styleOverrides
         ]}>
-        <a
-          href="mailto:hello@formidable.com"
-          style={[
-            headerStyles.link,
-            this.props.linkStyles && headerStyles.linkStyles
-          ]}>
-          {this.props.children}
-        </a>
+        <span style={{display: "block"}}>
+          <a
+            href="mailto:hello@formidable.com"
+            style={[
+              headerStyles.link,
+              this.props.linkStyles && headerStyles.linkStyles
+            ]}>
+            {this.props.children}
+          </a>
+        </span>
       </header>
     );
   }

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -6,10 +6,7 @@ class Header extends React.Component {
   getHeaderStyles() {
     return {
       base: {
-        display: "flex",
-        flexWrap: "wrap",
-        listStyle: "none",
-        justifyContent: "space-between",
+        display: "block",
         margin: 0,
         padding: "1rem 0.5rem",
         backgroundColor: this.props.backgroundColor,

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -50,16 +50,12 @@ class Header extends React.Component {
 
 Header.propTypes = {
   backgroundColor: React.PropTypes.string,
-  children: React.PropTypes.node,
-  linkStyles: React.PropTypes.object,
-  styleOverrides: React.PropTypes.object
+  children: React.PropTypes.node
 };
 
 Header.defaultProps = {
   backgroundColor: "#ebe3db",
-  children: "Need React.js consulting? Let’s talk.",
-  linkStyles: null,
-  styleOverrides: null
+  children: "Need React.js consulting? Let’s talk."
 };
 
 export default Header;

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -3,7 +3,6 @@ import Radium from "radium";
 
 @Radium
 class Header extends React.Component {
-
   getHeaderStyles() {
     return {
       base: {
@@ -17,6 +16,11 @@ class Header extends React.Component {
         textAlign: "center",
         borderBottom: "1px solid rgba(35, 31, 32, 0.02)"
       },
+      link: {
+        margin: "0 auto",
+        lineHeight: 1
+      },
+      linkStyles: this.props.linkStyles,
       styleOverrides: this.props.styleOverrides
     };
   }
@@ -29,7 +33,12 @@ class Header extends React.Component {
           headerStyles.base,
           this.props.styleOverrides && headerStyles.styleOverrides
         ]}>
-        <a href="mailto:hello@formidable.com" style={{margin: "0 auto", lineHeight: 1}}>
+        <a
+          href="mailto:hello@formidable.com"
+          style={[
+            headerStyles.link,
+            this.props.linkStyles && headerStyles.linkStyles
+          ]}>
           {this.props.children}
         </a>
       </header>
@@ -40,12 +49,14 @@ class Header extends React.Component {
 Header.propTypes = {
   backgroundColor: React.PropTypes.string,
   children: React.PropTypes.node,
+  linkStyles: React.PropTypes.object,
   styleOverrides: React.PropTypes.object
 };
 
 Header.defaultProps = {
   backgroundColor: "#ebe3db",
   children: "Need React.js consulting? Let’s talk.",
+  linkStyles: null,
   styleOverrides: null
 };
 


### PR DESCRIPTION
- Add `linkStyles` props to the links in `<Header />` and `<Footer />`
- Remove box shadows, background colors, and borders on the Formidable logo link
- Add `<span>` wrapper with `display: block` on `<Header />` to resolve https://github.com/FormidableLabs/formidable-landers/issues/52
- Bump version 

/cc @coopy @david-davidson 