### PR TITLE
Bug: Fix alignment in header and add setup for sticky footer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formidable-landers",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Reusable components for Formidable's marketing sites",
   "main": "lib/index.js",
   "scripts": {

--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -6,7 +6,7 @@ class Footer extends React.Component {
   getFooterStyles() {
     return {
       base: {
-        listStyle: "none",
+        flex: "none", // Sticky footer setup
         margin: "1rem 0 0 0",
         padding: "3rem 0.5rem",
         backgroundColor: this.props.backgroundColor,

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -6,10 +6,7 @@ class Header extends React.Component {
   getHeaderStyles() {
     return {
       base: {
-        display: "flex",
-        flexWrap: "wrap",
-        listStyle: "none",
-        justifyContent: "space-between",
+        flex: "none",  // Sticky footer setup
         margin: 0,
         padding: "1rem 0.5rem",
         backgroundColor: this.props.backgroundColor,
@@ -33,7 +30,7 @@ class Header extends React.Component {
           headerStyles.base,
           this.props.styleOverrides && headerStyles.styleOverrides
         ]}>
-        <span style={{display: "block"}}>
+        <span style={{display: "block", margin: "0 auto"}}>
           <a
             href="mailto:hello@formidable.com"
             style={[


### PR DESCRIPTION
- Center text in Header
- Contrary to my previous belief, `<Header />` and `<Footer />` actually need `flex: none` to setup the page for sticky footer behavior, see https://github.com/philipwalton/solved-by-flexbox/blob/master/assets/css/components/site.css#L15-L18

/cc @david-davidson 