### PR TITLE
Task: Add logo source path as a prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Our goal is consistent branding and wording across all of our visible projects. 
 
 Add `formidable-landers` as a dependency.
 ```
-npm install formidable-landers --save-dev
+npm install formidable-landers --save
 ```
 
 Import the desired components and any variables/settings if available.

--- a/README.md
+++ b/README.md
@@ -4,15 +4,70 @@ Welcome to the HQ of maintaining our visible Formidable projects. Our issues cap
 
 Our goal is consistent branding and wording across all of our visible projects. For example, they should all have the same header and footer.
 
-## Our Projects:
+## Install and Usage
 
-| Project | Githup Repo | Lander |
+Add `formidable-landers` as a dependency.
+```
+npm install formidable-landers --save-dev
+```
+
+Import the desired components and any variables/settings if available.
+```jsx
+import { Header, Footer } from "formidable-landers";
+```
+```jsx
+import { VictorySettings, VictoryTheme, Header, Footer } from "formidable-landers";
+```
+
+Both the `<Header />` and `<Footer />` components can be dropped in as is or be customized. The default background colors are sandy, so I recommend adding a `backgroundColor` prop at minimum.
+```jsx
+<Header backgroundColor="#242121" />
+<Footer backgroundColor="#242121" />
+```
+
+All the available customizations:
+```jsx
+<Header
+  backgroundColor={VictorySettings.palestSand}
+  styleOverrides={{
+    display: "block"
+  }}
+  linkStyles={{
+    color: "#c43a31",
+    ":hover": {
+      color: "#e58c7d"
+    }
+  }}>
+  Looking to level up your team?
+</Header>
+```
+
+```jsx
+<Footer
+  backgroundColor={VictorySettings.palestSand}
+  styleOverrides={{
+    display: "block"
+  }}
+  linkStyles={{
+    color: "#c43a31",
+    ":hover": {
+      color: "#e58c7d"
+    }
+  }}
+  footerLogo="img/logo.svg">
+  Please press [ space ] to continue.
+</Footer>
+```
+
+## Our Projects
+
+| Project | Source      | Lander |
 | ------- | ----------- | ------ |
-| Builder | [FormidableLabs/builder-docs](https://github.com/FormidableLabs/builder-docs) | - |
+| Builder | [FormidableLabs/builder-docs](https://github.com/FormidableLabs/builder-docs) | http://builder.formidable.com |
 | Ecology | [FormidableLabs/ecology](https://github.com/FormidableLabs/ecology) | - |
 | ES6 Interactive Guide | [FormidableLabs/es6-interactive-guide](https://github.com/FormidableLabs/es6-interactive-guide) | http://stack.formidable.com/es6-interactive-guide/ |
 | Stack. | [FormidableLabs/formidablelabs.github.io ](https://github.com/FormidableLabs/victory) | http://stack.formidable.com/ |
-| Radium | [FormidableLabs/radium](https://github.com/FormidableLabs/radium) | http://projects.formidablelabs.com/radium/ |
+| Radium | [FormidableLabs/radium](https://github.com/FormidableLabs/radium) | http://stack.formidable.com/radium/ |
 | Spectacle | [FormidableLabs/spectacle](https://github.com/FormidableLabs/spectacle) | http://stack.formidable.com/spectacle/ |
 | Victory | [FormidableLabs/victory](https://github.com/FormidableLabs/victory) | http://victory.formidable.com/ |
 
@@ -20,13 +75,21 @@ Our goal is consistent branding and wording across all of our visible projects. 
 - All projects with landers (except Radium) are built on React
 - Radium is built on jekyll
 
-### Global header & footer
-| Project | Source |
-| ------- | ----------- |
-| Builder | formidable-landers' `<Header />` |
-| Ecology | - |
-| ES6 Interactive Guide | [Footer](https://github.com/FormidableLabs/es6-interactive-guide/blob/gh-pages/components/footer.jsx) |
-| Stack. | [Header](https://github.com/FormidableLabs/formidablelabs.github.io/blob/master/js/header.jsx), [Footer](https://github.com/FormidableLabs/formidablelabs.github.io/blob/master/js/footer.jsx) |
-| Radium | [Header](https://github.com/FormidableLabs/radium/blob/gh-pages/_layouts/default.html#L28-L31), [Footer](https://github.com/FormidableLabs/radium/blob/gh-pages/_layouts/default.html#L64-L76) |
-| Spectacle | [gh-pages](https://github.com/FormidableLabs/spectacle/tree/gh-pages) |
-| Victory | formidable-landers' `<Header />` |
+## Publish
+
+1. Merge your PR into `master`.
+
+2. Add a new version
+```sh
+npm version major|minor|patch -m "Version %s - INSERT_REASONS"
+```
+
+3. Publish
+```sh
+npm publish
+```
+
+4. Push commit with tags
+```sh
+git push origin master --tags
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formidable-landers",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Reusable components for Formidable's marketing sites",
   "main": "lib/index.js",
   "scripts": {

--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -35,7 +35,6 @@ class Footer extends React.Component {
 
   render() {
     const footerStyles = this.getFooterStyles();
-    const footerLogo = this.props.footerLogo ? this.props.footerLogo : "static/logo-formidable-black.svg";
     return (
       <footer
         style={[
@@ -73,7 +72,7 @@ Footer.propTypes = {
 
 Footer.defaultProps = {
   backgroundColor: "#ebe3db",
-  footerLogo: null
+  footerLogo: "static/logo-formidable-black.svg"
 };
 
 export default Footer;

--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -35,6 +35,7 @@ class Footer extends React.Component {
 
   render() {
     const footerStyles = this.getFooterStyles();
+    const footerLogo = this.props.footerLogo ? this.props.footerLogo : "static/logo-formidable-black.svg";
     return (
       <footer
         style={[
@@ -47,12 +48,12 @@ class Footer extends React.Component {
         <span style={[footerStyles.text]}>
           <a href="http://formidable.com/" style={footerStyles.linkLogo}>
             <img width="300px" height="100px"
-              src="static/logo-formidable-black.svg"
+              src={footerLogo}
               alt="Formidable" />
           </a>
         </span>
         <span style={[footerStyles.text]}>
-          P.S. <a href="http://formidable.com/studio/"
+          P.S. <a href="http://formidable.com/team/"
             style={[this.props.linkStyles && footerStyles.linkStyles]}>
             We’re hiring
           </a>.
@@ -66,11 +67,13 @@ class Footer extends React.Component {
 }
 
 Footer.propTypes = {
-  backgroundColor: React.PropTypes.string
+  backgroundColor: React.PropTypes.string,
+  footerLogo: React.PropTypes.string
 };
 
 Footer.defaultProps = {
-  backgroundColor: "#ebe3db"
+  backgroundColor: "#ebe3db",
+  footerLogo: null
 };
 
 export default Footer;


### PR DESCRIPTION
- Add usage to `README.md`
- Since the formidable logo needs to be hosted in the project that consumes `formidable-landers`, convert the image source path to a prop so as not to restrict where it lives or its name
- Bump to version v0.0.8 

