### PR TITLE
Bug: footer logo is undefined

### DIFF
--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -47,7 +47,7 @@ class Footer extends React.Component {
         <span style={[footerStyles.text]}>
           <a href="http://formidable.com/" style={footerStyles.linkLogo}>
             <img width="300px" height="100px"
-              src={footerLogo}
+              src={this.props.footerLogo}
               alt="Formidable" />
           </a>
         </span>


### PR DESCRIPTION
The `const footerLogo` was removed in favor of default props, so it’s in props now, silly! 

/cc @coopy @tptee 