### PR TITLE
Victory docs: style non-ecology code blocks

### DIFF
--- a/src/themes/victory.js
+++ b/src/themes/victory.js
@@ -263,6 +263,15 @@ export default {
   ".Overview pre": {
     overflow: "hidden" // Hide horizontal scrollbars for playgrounds.
   },
+  ".Overview pre code": { // Non-ecology code blocks
+    display: "block",
+    padding: "16px",
+    background: settings.whiteSand,
+    fontFamily: settings.monospace,
+    fontSize: "1rem",
+    lineHeight: 1.2,
+    border: `1px solid ${settings.palestSand}`
+  },
   /*
    * Interactive/Component Playground
    */
@@ -288,20 +297,20 @@ export default {
   ".Interactive .playgroundCode": {
     flex: "0 0 100%",
     verticalAlign: "top",
+    marginBottom: "30px",
+    padding: "16px 16px 0 16px",
     background: "#fff",
     fontFamily: settings.monospace,
     fontSize: "1rem",
     lineHeight: 1.2,
-    marginBottom: "30px",
-    padding: "16px 16px 0 16px",
-    border: "1px solid #ebe3db"
+    border: `1px solid ${settings.palestSand}`
   },
   ".Interactive .playgroundPreview": {
     flex: "0 0 100%",
     verticalAlign: "top",
     background: "#fff",
     position: "relative",
-    border: "1px solid #ebe3db"
+    border: `1px solid ${settings.palestSand}`
   },
   ".Interactive .playgroundPreview:before": {
     content: "'Live Preview'",


### PR DESCRIPTION
Resolves https://github.com/FormidableLabs/victory/issues/182

Chose to not use the white background to help show these code blocks are **not** interactive.

<img width="846" alt="screen shot 2016-03-25 at 2 42 34 pm" src="https://cloud.githubusercontent.com/assets/768965/14054629/e1d70368-f297-11e5-9173-f98ff35ed233.png">