### PR TITLE
Rename backgroundColor, refactor styles through props

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 100
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,8 @@
----
-"extends":
-  - "defaults/configurations/walmart/es6-browser"
-
-"parser": "babel-eslint"
-
-"rules":
-  "no-extra-parens": [0]
+{
+  "extends": "defaults/configurations/walmart/es6-browser",
+  "parser": "babel-eslint",
+  "plugins": [ "react" ],
+  "rules": {
+    "no-extra-parens": 0
+  }
+}

--- a/README.md
+++ b/README.md
@@ -29,15 +29,10 @@ All the available customizations:
 ```jsx
 <Header
   background={VictorySettings.palestSand}
-  styleOverrides={{
-    display: "block"
-  }}
-  linkStyles={{
-    color: "#c43a31",
-    ":hover": {
-      color: "#e58c7d"
-    }
-  }}>
+  baseStyles={{ display: "block" }}
+  linkStyles={{ color: #c43a31 }}
+  linkWrapperStyles={{textAlign: "center", margin: "0 auto"}}
+>
   Looking to level up your team?
 </Header>
 ```
@@ -45,16 +40,16 @@ All the available customizations:
 ```jsx
 <Footer
   background={VictorySettings.palestSand}
-  styleOverrides={{
-    display: "block"
-  }}
+  baseStyles={{display: "block"}}
+  textStyles={{color: VictorySettings.red}}
   linkStyles={{
     color: "#c43a31",
-    ":hover": {
-      color: "#e58c7d"
-    }
+    ":hover": { color: "#e58c7d" }
   }}
-  footerLogo="img/logo.svg">
+  unstyledLinkStyles={{textDecoration: "none"}}
+  logoWrapperStyles={{textAlign: "center", margin: "0 auto"}}
+  logoColor="black"
+>
   Please press [ space ] to continue.
 </Footer>
 ```

--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ import { Header, Footer } from "formidable-landers";
 import { VictorySettings, VictoryTheme, Header, Footer } from "formidable-landers";
 ```
 
-Both the `<Header />` and `<Footer />` components can be dropped in as is or be customized. The default background colors are sandy, so I recommend adding a `backgroundColor` prop at minimum.
+Both the `<Header />` and `<Footer />` components can be dropped in as is or be customized. The default background colors are sandy, so I recommend adding a `background` prop at minimum.
 ```jsx
-<Header backgroundColor="#242121" />
-<Footer backgroundColor="#242121" />
+<Header background="#242121" />
+<Footer background="#242121" />
 ```
 
 All the available customizations:
 ```jsx
 <Header
-  backgroundColor={VictorySettings.palestSand}
+  background={VictorySettings.palestSand}
   styleOverrides={{
     display: "block"
   }}
@@ -44,7 +44,7 @@ All the available customizations:
 
 ```jsx
 <Footer
-  backgroundColor={VictorySettings.palestSand}
+  background={VictorySettings.palestSand}
   styleOverrides={{
     display: "block"
   }}

--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -4,66 +4,30 @@ import Radium from "radium";
 import { BlackFormidableLogo, WhiteFormidableLogo } from "../assets/logos";
 
 class Footer extends React.Component {
-  getFooterStyles() {
-    return {
-      base: {
-        flex: "none", // Sticky footer setup
-        margin: "1rem 0 0 0",
-        padding: "3rem 0.5rem",
-        background: this.props.background,
-        textAlign: "center",
-        borderTop: "1px solid rgba(35, 31, 32, 0.02)"
-      },
-      text: {
-        display: "block"
-      },
-      unstyledLink: {
-        display: "block",
-        boxShadow: "none",
-        border: "none",
-        textDecoration: "none",
-        ":hover": {
-          background: "transparent",
-          boxShadow: "none",
-          border: "none",
-          textDecoration: "none"
-        }
-      },
-      linkStyles: this.props.linkStyles,
-      styleOverrides: this.props.styleOverrides
-    };
-  }
-
   render() {
-    const footerStyles = this.getFooterStyles();
     return (
       <footer
-        style={[
-          footerStyles.base,
-          this.props.styleOverrides && footerStyles.styleOverrides
-        ]}>
-        <span style={[footerStyles.text]}>
-          Made with love by
-        </span>
-        <span style={[footerStyles.text]}>
+        style={this.props.footerStyles}>
+        <span style={this.props.footerTextStyles}>Made with love by</span>
+        <span style={this.props.footerTextStyles}>
           <a
             key="fl-logo"
             href="http://formidable.com/"
-            style={footerStyles.unstyledLink}>
+            style={this.props.footerUnstyledLink}>
             <span style={{width: "300px", height: "100px"}}>
               {this.props.logoColor === "white" ? WhiteFormidableLogo : BlackFormidableLogo}
             </span>
           </a>
         </span>
-        <span style={[footerStyles.text]}>
+        <span style={this.props.footerTextStyles}>
           P.S. <a
           key="fl-hiring"
           href="http://formidable.com/careers/"
-          style={[this.props.linkStyles && footerStyles.linkStyles]}>
+          style={this.props.footerLinkStyles}>
             We’re hiring
           </a>.
         </span>
-        <span style={[footerStyles.text]}>
+        <span style={this.props.footerTextStyles}>
           {this.props.children}
         </span>
       </footer>
@@ -72,12 +36,37 @@ class Footer extends React.Component {
 }
 
 Footer.propTypes = {
-  background: React.PropTypes.string,
+  footerStyles: React.PropTypes.object,
+  footerTextStyles: React.PropTypes.object,
+  footerUnstyledLinkStyles: React.PropTypes.object,
+  footerLinkStyles: React.PropTypes.object,
   logoColor: React.PropTypes.oneOf(["black", "white"])
 };
 
 Footer.defaultProps = {
-  background: "#ebe3db",
+  footerStyles: {
+    flex: "none", // Sticky footer setup
+    margin: "1rem 0 0 0",
+    padding: "3rem 0.5rem",
+    background: "#ebe3db",
+    textAlign: "center",
+    borderTop: "1px solid rgba(35, 31, 32, 0.02)"
+  },
+  footerTextStyles: {
+    display: "block"
+  },
+  footerUnstyledLinkStyles: {
+    display: "block",
+    boxShadow: "none",
+    border: "none",
+    textDecoration: "none",
+    ":hover": {
+      background: "transparent",
+      boxShadow: "none",
+      border: "none",
+      textDecoration: "none"
+    }
+  },
   logoColor: "black"
 };
 

--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -10,7 +10,7 @@ class Footer extends React.Component {
         flex: "none", // Sticky footer setup
         margin: "1rem 0 0 0",
         padding: "3rem 0.5rem",
-        backgroundColor: this.props.backgroundColor,
+        background: this.props.background,
         textAlign: "center",
         borderTop: "1px solid rgba(35, 31, 32, 0.02)"
       },
@@ -23,7 +23,7 @@ class Footer extends React.Component {
         border: "none",
         textDecoration: "none",
         ":hover": {
-          backgroundColor: "transparent",
+          background: "transparent",
           boxShadow: "none",
           border: "none",
           textDecoration: "none"
@@ -72,12 +72,12 @@ class Footer extends React.Component {
 }
 
 Footer.propTypes = {
-  backgroundColor: React.PropTypes.string,
+  background: React.PropTypes.string,
   logoColor: React.PropTypes.oneOf(["black", "white"])
 };
 
 Footer.defaultProps = {
-  backgroundColor: "#ebe3db",
+  background: "#ebe3db",
   logoColor: "black"
 };
 

--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -7,27 +7,30 @@ class Footer extends React.Component {
   render() {
     return (
       <footer
-        style={this.props.footerStyles}>
-        <span style={this.props.footerTextStyles}>Made with love by</span>
-        <span style={this.props.footerTextStyles}>
+        style={[
+          this.props.baseStyles,
+          {background: this.props.background}
+        ]}>
+        <span style={this.props.textStyles}>Made with love by</span>
+        <span style={this.props.textStyles}>
           <a
             key="fl-logo"
             href="http://formidable.com/"
-            style={this.props.footerUnstyledLink}>
-            <span style={{width: "300px", height: "100px"}}>
+            style={this.props.unstyledLinkStyles}>
+            <span style={this.props.logoWrapperStyles}>
               {this.props.logoColor === "white" ? WhiteFormidableLogo : BlackFormidableLogo}
             </span>
           </a>
         </span>
-        <span style={this.props.footerTextStyles}>
+        <span style={this.props.textStyles}>
           P.S. <a
           key="fl-hiring"
           href="http://formidable.com/careers/"
-          style={this.props.footerLinkStyles}>
+          style={this.props.linkStyles}>
             We’re hiring
           </a>.
         </span>
-        <span style={this.props.footerTextStyles}>
+        <span style={this.props.textStyles}>
           {this.props.children}
         </span>
       </footer>
@@ -36,26 +39,30 @@ class Footer extends React.Component {
 }
 
 Footer.propTypes = {
-  footerStyles: React.PropTypes.object,
-  footerTextStyles: React.PropTypes.object,
-  footerUnstyledLinkStyles: React.PropTypes.object,
-  footerLinkStyles: React.PropTypes.object,
-  logoColor: React.PropTypes.oneOf(["black", "white"])
+  background: React.PropTypes.string,
+  baseStyles: React.PropTypes.object,
+  textStyles: React.PropTypes.object,
+  linkStyles: React.PropTypes.object,
+  unstyledLinkStyles: React.PropTypes.object,
+  logoWrapperStyles: React.PropTypes.object,
+  logoColor: React.PropTypes.oneOf(["black", "white"]),
+  children: React.PropTypes.node
 };
 
 Footer.defaultProps = {
-  footerStyles: {
+  background: "#ebe3db",
+  baseStyles: {
     flex: "none", // Sticky footer setup
     margin: "1rem 0 0 0",
     padding: "3rem 0.5rem",
-    background: "#ebe3db",
     textAlign: "center",
     borderTop: "1px solid rgba(35, 31, 32, 0.02)"
   },
-  footerTextStyles: {
+  textStyles: {
     display: "block"
   },
-  footerUnstyledLinkStyles: {
+  linkStyles: {},
+  unstyledLinkStyles: {
     display: "block",
     boxShadow: "none",
     border: "none",
@@ -66,6 +73,10 @@ Footer.defaultProps = {
       border: "none",
       textDecoration: "none"
     }
+  },
+  logoWrapperStyles: {
+    width: "300px",
+    height: "100px"
   },
   logoColor: "black"
 };

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -19,7 +19,9 @@ class Header extends React.Component {
 }
 
 Header.propTypes = {
-  styles: React.PropTypes.object,
+  headerStyles: React.PropTypes.object,
+  headerLinkStyles: React.PropTypes.object,
+  headerLinkWrapperStyles: React.PropTypes.object,
   children: React.PropTypes.node
 };
 

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -2,41 +2,14 @@ import React from "react";
 import Radium from "radium";
 
 class Header extends React.Component {
-  getHeaderStyles() {
-    return {
-      base: {
-        flex: "none",  // Sticky footer setup
-        margin: 0,
-        padding: "1rem 0.5rem",
-        background: this.props.background,
-        textAlign: "center",
-        borderBottom: "1px solid rgba(35, 31, 32, 0.02)"
-      },
-      link: {
-        margin: "0 auto",
-        lineHeight: 1
-      },
-      linkStyles: this.props.linkStyles,
-      styleOverrides: this.props.styleOverrides
-    };
-  }
-
   render() {
-    const headerStyles = this.getHeaderStyles();
     return (
-      <header
-        style={[
-          headerStyles.base,
-          this.props.styleOverrides && headerStyles.styleOverrides
-        ]}>
-        <span style={{display: "block", margin: "0 auto"}}>
+      <header style={this.props.headerStyles}>
+        <span style={this.props.headerLinkWrapperStyles}>
           <a
           key="fl-header"
           href="http://formidable.com/careers/"
-          style={[
-            headerStyles.link,
-            this.props.linkStyles && headerStyles.linkStyles
-          ]}>
+          style={this.props.headerLinkStyles}>
             {this.props.children}
           </a>
         </span>
@@ -46,12 +19,27 @@ class Header extends React.Component {
 }
 
 Header.propTypes = {
-  background: React.PropTypes.string,
+  styles: React.PropTypes.object,
   children: React.PropTypes.node
 };
 
 Header.defaultProps = {
-  background: "#ebe3db",
+  headerStyles: {
+    flex: "none",  // Sticky footer setup
+    margin: 0,
+    padding: "1rem 0.5rem",
+    background: "#ebe3db",
+    textAlign: "center",
+    borderBottom: "1px solid rgba(35, 31, 32, 0.02)"
+  },
+  headerLinkStyles: {
+    margin: "0 auto",
+    lineHeight: 1
+  },
+  headerLinkWrapperStyles: {
+    display: "block",
+    margin: "0 auto"
+  },
   children: "We’re hiring!"
 };
 

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -4,12 +4,15 @@ import Radium from "radium";
 class Header extends React.Component {
   render() {
     return (
-      <header style={this.props.headerStyles}>
-        <span style={this.props.headerLinkWrapperStyles}>
+      <header style={[
+        this.props.baseStyles,
+        {background: this.props.background}
+      ]}>
+        <span style={this.props.linkWrapperStyles}>
           <a
           key="fl-header"
           href="http://formidable.com/careers/"
-          style={this.props.headerLinkStyles}>
+          style={this.props.linkStyles}>
             {this.props.children}
           </a>
         </span>
@@ -19,26 +22,27 @@ class Header extends React.Component {
 }
 
 Header.propTypes = {
-  headerStyles: React.PropTypes.object,
-  headerLinkStyles: React.PropTypes.object,
-  headerLinkWrapperStyles: React.PropTypes.object,
+  background: React.PropTypes.string,
+  baseStyles: React.PropTypes.object,
+  linkStyles: React.PropTypes.object,
+  linkWrapperStyles: React.PropTypes.object,
   children: React.PropTypes.node
 };
 
 Header.defaultProps = {
-  headerStyles: {
+  background: "#ebe3db",
+  baseStyles: {
     flex: "none",  // Sticky footer setup
     margin: 0,
     padding: "1rem 0.5rem",
-    background: "#ebe3db",
     textAlign: "center",
     borderBottom: "1px solid rgba(35, 31, 32, 0.02)"
   },
-  headerLinkStyles: {
+  linkStyles: {
     margin: "0 auto",
     lineHeight: 1
   },
-  headerLinkWrapperStyles: {
+  linkWrapperStyles: {
     display: "block",
     margin: "0 auto"
   },

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -8,7 +8,7 @@ class Header extends React.Component {
         flex: "none",  // Sticky footer setup
         margin: 0,
         padding: "1rem 0.5rem",
-        backgroundColor: this.props.backgroundColor,
+        background: this.props.background,
         textAlign: "center",
         borderBottom: "1px solid rgba(35, 31, 32, 0.02)"
       },
@@ -46,12 +46,12 @@ class Header extends React.Component {
 }
 
 Header.propTypes = {
-  backgroundColor: React.PropTypes.string,
+  background: React.PropTypes.string,
   children: React.PropTypes.node
 };
 
 Header.defaultProps = {
-  backgroundColor: "#ebe3db",
+  background: "#ebe3db",
   children: "We’re hiring!"
 };
 

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,11 @@
+{
+  "extends": "defaults/configurations/walmart/es6-test",
+  "parser": "babel-eslint",
+  "plugins": [ "react" ],
+  "globals": { "expect": true },
+  "rules": {
+    "react/jsx-uses-vars": 2,
+    "react/jsx-uses-react": 2,
+    "react/react-in-jsx-scope": 2,
+  }
+}

--- a/test/src/components/footer.spec.js
+++ b/test/src/components/footer.spec.js
@@ -1,5 +1,6 @@
+/* eslint-disable max-len, no-unused-expressions */
 import React from "react";
-import { shallow, render } from "enzyme";
+import { shallow } from "enzyme";
 
 import Footer from "../../../src/components/footer";
 import { BlackFormidableLogo, WhiteFormidableLogo } from "../../../src/assets/logos";
@@ -15,15 +16,15 @@ describe("Footer", () => {
         msFlex: "none",
         margin: "1rem 0 0 0",
         padding: "3rem 0.5rem",
-        backgroundColor: "#ebe3db",
         textAlign: "center",
-        borderTop: "1px solid rgba(35, 31, 32, 0.02)"
+        borderTop: "1px solid rgba(35, 31, 32, 0.02)",
+        background: "#ebe3db"
       };
       expect(footer.props().style).to.deep.equal(defaultStyles);
     });
 
     it("accepts custom styles", () => {
-      const footer = shallow(<Footer styleOverrides={{margin: "20px 40px 60px"}} />);
+      const footer = shallow(<Footer baseStyles={{margin: "20px 40px 60px"}} />);
       expect(footer.props().style).to.have.property("margin", "20px 40px 60px");
     });
   });

--- a/test/src/components/header.spec.js
+++ b/test/src/components/header.spec.js
@@ -12,36 +12,36 @@ describe("Header", () => {
     });
 
     it("accepts custom styles", () => {
-      const header = shallow(<Header styleOverrides={{textAlign: "left"}} />);
+      const header = shallow(<Header baseStyles={{textAlign: "left"}} />);
       expect(header.props().style).to.have.property("textAlign", "left");
     });
   });
 
   describe("call to action", () => {
     it("links to our careers pages", () => {
-      const headerLink = shallow(<Header />).find('a');
+      const headerLink = shallow(<Header />).find("a");
       expect(headerLink).to.have.length(1);
       expect(headerLink.props()).to.have.property("href", "http://formidable.com/careers/");
     });
 
     it("has a default message", () => {
-      const headerLink = shallow(<Header />).find('a');
+      const headerLink = shallow(<Header />).find("a");
       expect(headerLink.text()).to.equal("We’re hiring!");
     });
 
     it("accepts a custom message", () => {
-      const headerLink = shallow(<Header>Need help leveling up? Contact us!</Header>).find('a');
+      const headerLink = shallow(<Header>Need help leveling up? Contact us!</Header>).find("a");
       expect(headerLink.text()).to.equal("Need help leveling up? Contact us!");
       expect(headerLink.props()).to.have.property("href", "http://formidable.com/careers/");
     });
 
     it("has default styles", () => {
-      const headerLink = shallow(<Header />).find('a');
+      const headerLink = shallow(<Header />).find("a");
       expect(headerLink.props()).to.have.property("style");
     });
 
     it("accepts custom styles", () => {
-      const headerLink = shallow(<Header linkStyles={{lineHeight: 2}} />).find('a');
+      const headerLink = shallow(<Header linkStyles={{lineHeight: 2}} />).find("a");
       expect(headerLink.props().style).to.have.property("lineHeight", 2);
     });
   });


### PR DESCRIPTION
Currently, headers or footers that use a `background` property to apply linear-gradients or other sorts of css images receive a radium error because of long & shorthand properties within the same object.

Will be a breaking change, as the backgroundColor prop will no longer be applied.

Fixes https://github.com/FormidableLabs/builder-docs/pull/24

cc @coopy 