### PR TITLE
Rename prop backgroundColor -> background

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 100
+
+[*.md]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ import { Header, Footer } from "formidable-landers";
 import { VictorySettings, VictoryTheme, Header, Footer } from "formidable-landers";
 ```
 
-Both the `<Header />` and `<Footer />` components can be dropped in as is or be customized. The default background colors are sandy, so I recommend adding a `backgroundColor` prop at minimum.
+Both the `<Header />` and `<Footer />` components can be dropped in as is or be customized. The default background colors are sandy, so I recommend adding a `background` prop at minimum.
 ```jsx
-<Header backgroundColor="#242121" />
-<Footer backgroundColor="#242121" />
+<Header background="#242121" />
+<Footer background="#242121" />
 ```
 
 All the available customizations:
 ```jsx
 <Header
-  backgroundColor={VictorySettings.palestSand}
+  background={VictorySettings.palestSand}
   styleOverrides={{
     display: "block"
   }}
@@ -44,7 +44,7 @@ All the available customizations:
 
 ```jsx
 <Footer
-  backgroundColor={VictorySettings.palestSand}
+  background={VictorySettings.palestSand}
   styleOverrides={{
     display: "block"
   }}

--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -10,7 +10,7 @@ class Footer extends React.Component {
         flex: "none", // Sticky footer setup
         margin: "1rem 0 0 0",
         padding: "3rem 0.5rem",
-        backgroundColor: this.props.backgroundColor,
+        background: this.props.background,
         textAlign: "center",
         borderTop: "1px solid rgba(35, 31, 32, 0.02)"
       },
@@ -23,7 +23,7 @@ class Footer extends React.Component {
         border: "none",
         textDecoration: "none",
         ":hover": {
-          backgroundColor: "transparent",
+          background: "transparent",
           boxShadow: "none",
           border: "none",
           textDecoration: "none"
@@ -72,12 +72,12 @@ class Footer extends React.Component {
 }
 
 Footer.propTypes = {
-  backgroundColor: React.PropTypes.string,
+  background: React.PropTypes.string,
   logoColor: React.PropTypes.oneOf(["black", "white"])
 };
 
 Footer.defaultProps = {
-  backgroundColor: "#ebe3db",
+  background: "#ebe3db",
   logoColor: "black"
 };
 

--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -10,7 +10,6 @@ class Footer extends React.Component {
         flex: "none", // Sticky footer setup
         margin: "1rem 0 0 0",
         padding: "3rem 0.5rem",
-        background: this.props.background,
         textAlign: "center",
         borderTop: "1px solid rgba(35, 31, 32, 0.02)"
       },
@@ -40,6 +39,7 @@ class Footer extends React.Component {
       <footer
         style={[
           footerStyles.base,
+          { background: this.props.background },
           this.props.styleOverrides && footerStyles.styleOverrides
         ]}>
         <span style={[footerStyles.text]}>

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -8,7 +8,6 @@ class Header extends React.Component {
         flex: "none",  // Sticky footer setup
         margin: 0,
         padding: "1rem 0.5rem",
-        background: this.props.background,
         textAlign: "center",
         borderBottom: "1px solid rgba(35, 31, 32, 0.02)"
       },
@@ -27,6 +26,7 @@ class Header extends React.Component {
       <header
         style={[
           headerStyles.base,
+          { background: this.props.background },
           this.props.styleOverrides && headerStyles.styleOverrides
         ]}>
         <span style={{display: "block", margin: "0 auto"}}>

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -8,7 +8,7 @@ class Header extends React.Component {
         flex: "none",  // Sticky footer setup
         margin: 0,
         padding: "1rem 0.5rem",
-        backgroundColor: this.props.backgroundColor,
+        background: this.props.background,
         textAlign: "center",
         borderBottom: "1px solid rgba(35, 31, 32, 0.02)"
       },
@@ -46,12 +46,12 @@ class Header extends React.Component {
 }
 
 Header.propTypes = {
-  backgroundColor: React.PropTypes.string,
+  background: React.PropTypes.string,
   children: React.PropTypes.node
 };
 
 Header.defaultProps = {
-  backgroundColor: "#ebe3db",
+  background: "#ebe3db",
   children: "We’re hiring!"
 };
 

--- a/src/themes/victory.js
+++ b/src/themes/victory.js
@@ -16,7 +16,7 @@ export default {
     textSizeAdjust: "100%"
   },
   body: {
-    backgroundColor: settings.palerSand,
+    background: settings.palerSand,
     fontFamily: settings.serif,
     fontSize: "18px",
     lineHeight: 1.4,
@@ -138,7 +138,7 @@ export default {
    * Buttons!
    */
   ".Button": {
-    backgroundColor: "transparent",
+    background: "transparent",
     border: `3px solid ${settings.palerSand}`,
     boxShadow: "none",
     color: settings.darkestSand,
@@ -264,7 +264,7 @@ export default {
    *          |- .previewArea
    */
   ".Interactive": {
-    backgroundColor: settings.whiteSand,
+    background: settings.whiteSand,
     margin: `${settings.gutter}px 0 ${settings.gutter * 2}px`,
     minHeight: "150px",
     width: "100%"
@@ -313,7 +313,7 @@ export default {
     textAlign: "center"
   },
   ".Interactive .playgroundError": {
-    backgroundColor: settings.paleRed,
+    background: settings.paleRed,
     color: settings.whiteSand,
     fontFamily: settings.monospace,
     fontSize: "1rem",
@@ -506,24 +506,24 @@ export default {
    */
   ".playgroundStage": {
     // Default state
-    backgroundColor: settings.codeMirror.bg,
+    background: settings.codeMirror.bg,
     color: settings.whiteSand,
     transition: "background-color 195ms ease-in"
   },
   ".playgroundStage.ReactCodeMirror--focused": {
     // Focused state
-    backgroundColor: settings.codeMirror.bgFocused,
+    background: settings.codeMirror.bgFocused,
     transition: "background-color 250ms ease-out"
   },
   ".cm-s-elegant .CodeMirror-selected": {
     // text selection
-    backgroundColor: settings.mud
+    background: settings.mud
   },
   ".cm-s-elegant .CodeMirror-activeline": {
-    backgroundColor: "#000000"
+    background: "#000000"
   },
   ".cm-s-elegant .CodeMirror-activeline-background": {
-    backgroundColor: "#000000"
+    background: "#000000"
   },
   ".cm-s-elegant .CodeMirror-gutters": {
     background: `${settings.darkMud} !important`

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,11 +1,11 @@
 {
-  "extends": "defaults/configurations/walmart/es6-browser",
+  "extends": "defaults/configurations/walmart/es6-test",
   "parser": "babel-eslint",
   "plugins": [ "react" ],
+  "globals": { "expect": true },
   "rules": {
     "react/jsx-uses-vars": 2,
     "react/jsx-uses-react": 2,
     "react/react-in-jsx-scope": 2,
-    "no-extra-parens": 0
   }
 }

--- a/test/src/components/footer.spec.js
+++ b/test/src/components/footer.spec.js
@@ -15,7 +15,7 @@ describe("Footer", () => {
         msFlex: "none",
         margin: "1rem 0 0 0",
         padding: "3rem 0.5rem",
-        backgroundColor: "#ebe3db",
+        background: "#ebe3db",
         textAlign: "center",
         borderTop: "1px solid rgba(35, 31, 32, 0.02)"
       };

--- a/test/src/components/footer.spec.js
+++ b/test/src/components/footer.spec.js
@@ -1,5 +1,6 @@
+/* eslint-disable max-len, no-unused-expressions */
 import React from "react";
-import { shallow, render } from "enzyme";
+import { shallow } from "enzyme";
 
 import Footer from "../../../src/components/footer";
 import { BlackFormidableLogo, WhiteFormidableLogo } from "../../../src/assets/logos";

--- a/test/src/components/header.spec.js
+++ b/test/src/components/header.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len, no-unused-expressions */
 import React from "react";
 import { shallow } from "enzyme";
 
@@ -19,29 +20,29 @@ describe("Header", () => {
 
   describe("call to action", () => {
     it("links to our careers pages", () => {
-      const headerLink = shallow(<Header />).find('a');
+      const headerLink = shallow(<Header />).find("a");
       expect(headerLink).to.have.length(1);
       expect(headerLink.props()).to.have.property("href", "http://formidable.com/careers/");
     });
 
     it("has a default message", () => {
-      const headerLink = shallow(<Header />).find('a');
+      const headerLink = shallow(<Header />).find("a");
       expect(headerLink.text()).to.equal("We’re hiring!");
     });
 
     it("accepts a custom message", () => {
-      const headerLink = shallow(<Header>Need help leveling up? Contact us!</Header>).find('a');
+      const headerLink = shallow(<Header>Need help leveling up? Contact us!</Header>).find("a");
       expect(headerLink.text()).to.equal("Need help leveling up? Contact us!");
       expect(headerLink.props()).to.have.property("href", "http://formidable.com/careers/");
     });
 
     it("has default styles", () => {
-      const headerLink = shallow(<Header />).find('a');
+      const headerLink = shallow(<Header />).find("a");
       expect(headerLink.props()).to.have.property("style");
     });
 
     it("accepts custom styles", () => {
-      const headerLink = shallow(<Header linkStyles={{lineHeight: 2}} />).find('a');
+      const headerLink = shallow(<Header linkStyles={{lineHeight: 2}} />).find("a");
       expect(headerLink.props().style).to.have.property("lineHeight", 2);
     });
   });


### PR DESCRIPTION
Use the `background` shorthand in cases where we pass gradient backgrounds & radium complains about long&shorthand definitions in the same collection.

This will fix https://github.com/FormidableLabs/builder-docs/pull/24

cc @paulathevalley 