### PR TITLE
Use link name when title is blank

### DIFF
--- a/src/markdown-renderers/append-link-icon.js
+++ b/src/markdown-renderers/append-link-icon.js
@@ -8,7 +8,7 @@ export default {
     const Icon = href.includes("formidable.com") ? IconInternalLink : IconExternalLink;
 
     return (
-      `<a href=${href} title=${title}>
+      `<a href=${href} title=${title || text}>
         ${text} <span style="margin: 0; padding: 0; display: inline-block; vertical-align: middle;">${Icon}</span>
       </a>`
     );

--- a/src/markdown-renderers/append-link-icon.js
+++ b/src/markdown-renderers/append-link-icon.js
@@ -8,7 +8,7 @@ export default {
     const Icon = href.includes("formidable.com") ? IconInternalLink : IconExternalLink;
 
     return (
-      `<a href=${href} title=${title || text}>
+      `<a href=${href} title=${title || ""}>
         ${text} <span style="margin: 0; padding: 0; display: inline-block; vertical-align: middle;">${Icon}</span>
       </a>`
     );


### PR DESCRIPTION
Sets title to text rather than null when title is not provided