### PR TITLE
Update Victory theme to stack recipe playgrounds vertically

### DIFF
--- a/src/themes/victory.js
+++ b/src/themes/victory.js
@@ -254,6 +254,24 @@ export default {
        11px -1px 0 0 ${settings.darkerSand}`
   },
   /*
+   * Vertically stacked playground for Recipes
+   * .Recipe
+   * |- pre
+   *    |- .Interactive
+   *       |- .playground
+   *          |- .playgroundCode
+   *          |- .playgroundPreview
+   */
+  ".Recipe .Interactive .playground": {
+    "flexDirection": "column"
+  },
+  ".Recipe .Interactive .playgroundCode": {
+    "flex": "none"
+  },
+  ".Recipe .Interactive .playgroundPreview": {
+    "flex": "none"
+  },
+  /*
    * Interactive/Component Playground
    * .Interactive
    * |- .playground
@@ -482,6 +500,9 @@ export default {
         left: 0,
         right: 0,
         bottom: 0
+      },
+      ".Recipe .Interactive .playground": {
+        marginLeft: 0
       },
       ".playgroundsMaxHeight .Interactive .playgroundStage": {
         maxHeight: "500px",


### PR DESCRIPTION
Once this change is published to npm, this will allow the Victory recipe playgrounds to stack vertically. See https://github.com/FormidableLabs/victory-examples/issues/28 for context.

/cc @paulathevalley, @kylecesmat 

New: 
![image](https://cloud.githubusercontent.com/assets/848347/16928618/75ffd79a-4ce8-11e6-80e5-8aedb2f0c4bb.png)

Previous:
![image](https://cloud.githubusercontent.com/assets/848347/16928642/94bba1be-4ce8-11e6-8387-30f3b8f77e43.png)

