### PR TITLE
Fix counter increment for playgrounds

### DIFF
--- a/src/themes/victory.js
+++ b/src/themes/victory.js
@@ -300,7 +300,7 @@ export default {
   },
   ".Interactive .playgroundPreview:after": {
     counterIncrement: "interactive",
-    content: "'Fig. ' counter(interactive) '.'",
+    content: `Fig. " counter(interactive) ".`,
     position: "absolute",
     right: 0,
     bottom: 0,


### PR DESCRIPTION
For some reason, the `counter-increment` stopped working. This fixes it. 

Bug: 
![screen shot 2016-07-18 at 1 36 57 pm](https://cloud.githubusercontent.com/assets/768965/16929784/14b133b6-4cee-11e6-8c5f-f817da734ff0.png)

Fix: 
![screen shot 2016-07-18 at 1 47 48 pm](https://cloud.githubusercontent.com/assets/768965/16929821/3dac8ad6-4cee-11e6-8d63-c1a3454b9444.png)

/cc @kylecesmat 