### PR TITLE
Dataset Dropdown Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to the HQ of maintaining our visible Formidable projects. Our issues capture the planning process for their landing pages.
 
-Our goal is consistent branding and wording across all of our visible projects. For example, they should all have the same header and footer.
+Our goal is to maintain consistent branding and wording across all of our visible projects. For example, they should all have the same header and footer.
 
 ## Install and Usage
 
@@ -11,53 +11,98 @@ Add `formidable-landers` as a dependency.
 npm install formidable-landers --save
 ```
 
+#### Header & Footer
 Import the desired components and any variables/settings if available.
 ```jsx
 import { Header, Footer } from "formidable-landers";
 ```
-```jsx
-import { VictorySettings, VictoryTheme, Header, Footer } from "formidable-landers";
-```
 
-Both the `<Header />` and `<Footer />` components can be dropped in as is or be customized. The default background colors are sandy, so I recommend adding a `background` prop at minimum.
+Both the `<Header />` and `<Footer />` components can be dropped in as is or be customized. The default background colors are sandy, so you should add a `background` prop at minimum.
 ```jsx
 <Header background="#242121" />
 <Footer background="#242121" />
 ```
 
-All the available customizations:
+Available props:
 ```jsx
 <Header
-  background={VictorySettings.palestSand}
-  styleOverrides={{
-    display: "block"
-  }}
-  linkStyles={{
-    color: "#c43a31",
-    ":hover": {
-      color: "#e58c7d"
-    }
-  }}>
+  background={string}
+  styleOverrides={obj}
+  linkStyles={obj}
+>
   Looking to level up your team?
 </Header>
 ```
 
 ```jsx
 <Footer
-  background={VictorySettings.palestSand}
-  styleOverrides={{
-    display: "block"
-  }}
-  linkStyles={{
-    color: "#c43a31",
-    ":hover": {
-      color: "#e58c7d"
-    }
-  }}
-  footerLogo="img/logo.svg">
+  background={string}
+  styleOverrides={obj}
+  linkStyles={obj}
+  logoColor={"white" || "black"}
+>
   Please press [ space ] to continue.
 </Footer>
 ```
+
+#### Themes & Settings
+We house some shared themes & settings here. Vicotry for example, is made up of multiple repositories, so we keep the styles in sync here.
+```jsx
+import { VictorySettings, VictoryTheme } from "formidable-landers";
+```
+
+#### Markdown Renderers
+Ecology uses marked, which supports custom renderer functions for markdown.
+```jsx
+import { appendLinkIcon, ecologyPlaygroundLoading } from "formidable-landers";
+```
+- __appendLinkIcon__: Adds either an external or internal icon to a link, depending if it is originating from `fomridable.com`. This is useful for providing routing context to the user.
+
+- __ecologyPlaygroundLoading__: This function adds classnames to codeblocks rendered by Ecology. This is useful for styling elements that are server-rendered while we are waiting for the client application to load.
+
+#### Other Components
+These are common functions/components that we might use across our internal properties.
+
+- __DatasetDropdown__: This component can be passed to ecology via scope, along with a dataset, and then used inside of an ecology playground to render a select dropdown. This allows a developer to show multiple datasets inside of a playground.
+
+Example dataset (dataset.js):
+```js
+export default [
+  {
+    id: 0,
+    label: "Positive",
+    data: [{x: 0, y: 0}, {x: 10, y: 20}, {x: 2, y: 1}]
+  },
+  {
+    id: 1,
+    label: "Negative",
+    data: [{x: 0, y: 0}, {x: -1, y: -2}, {x: -2, y: -1}]
+  }
+];
+```
+
+Example ecology playground (ecology.md):
+```
+```playground_norender
+class App extends React.Component {
+  render() {
+    return (
+      <VictoryChart>
+        <VictoryScatter
+          data={this.context.dataset}
+        />
+      </VictoryChart>
+    );
+  }
+}
+
+App.contextTypes = {
+  dataset: React.PropTypes.array
+};
+
+ReactDOM.render(<DatasetDropdown dataset={dataset}><App/></DatasetDropdown>, mountNode);
+```
+
 
 ## Our Projects
 

--- a/src/components/dataset-dropdown.jsx
+++ b/src/components/dataset-dropdown.jsx
@@ -1,0 +1,48 @@
+import React from "react";
+
+export default class DatasetDropdown extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { selectedDataset: 0 };
+    this.onDatasetSelect = this.onDatasetSelect.bind(this);
+  }
+
+  getChildContext() {
+    const { dataset } = this.props;
+    const { selectedDataset } = this.state;
+    return {
+      dataset: dataset[this.state ? selectedDataset : 0].data
+    };
+  }
+
+  onDatasetSelect(e) {
+    this.setState({ selectedDataset: e.target.selectedIndex });
+  }
+
+  render() {
+    const { dataset } = this.props;
+    return (
+      <div>
+        <select onChange={this.onDatasetSelect}>
+          {dataset.map((option) => (
+            <option key={option.id}>{option.label}</option>
+          ))}
+        </select>
+        {this.props.children}
+      </div>
+    );
+  }
+}
+
+DatasetDropdown.childContextTypes = {
+  dataset: React.PropTypes.array
+};
+
+DatasetDropdown.propTypes = {
+  dataset: React.PropTypes.arrayOf(React.PropTypes.shape({
+    id: React.PropTypes.any,
+    label: React.PropTypes.string,
+    data: React.PropTypes.array
+  })).isRequired,
+  children: React.PropTypes.node.isRequired
+};

--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -73,12 +73,16 @@ class Footer extends React.Component {
 
 Footer.propTypes = {
   background: React.PropTypes.string,
-  logoColor: React.PropTypes.oneOf(["black", "white"])
+  logoColor: React.PropTypes.oneOf(["black", "white"]),
+  linkStyles: React.PropTypes.object,
+  styleOverrides: React.PropTypes.object
 };
 
 Footer.defaultProps = {
   background: "#ebe3db",
-  logoColor: "black"
+  logoColor: "black",
+  linkStyles: null,
+  styleOverrides: null
 };
 
 export default Radium(Footer); //eslint-disable-line new-cap

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -47,12 +47,16 @@ class Header extends React.Component {
 
 Header.propTypes = {
   background: React.PropTypes.string,
-  children: React.PropTypes.node
+  children: React.PropTypes.node,
+  linkStyles: React.PropTypes.object,
+  styleOverrides: React.PropTypes.object
 };
 
 Header.defaultProps = {
   background: "#ebe3db",
-  children: "We’re hiring!"
+  children: "We’re hiring!",
+  linkStyles: null,
+  styleOverrides: null
 };
 
 export default Radium(Header); //eslint-disable-line new-cap

--- a/src/index.js
+++ b/src/index.js
@@ -2,14 +2,16 @@ import Header from "./components/header";
 import Footer from "./components/footer";
 import VictorySettings from "./themes/victory-settings";
 import VictoryTheme from "./themes/victory";
+import DatasetDropdown from "./components/dataset-dropdown";
 import appendLinkIcon from "./markdown-renderers/append-link-icon";
 import ecologyPlaygroundLoading from "./markdown-renderers/ecology-playground-loading";
 
 export {
-  Header,
-  Footer,
-  VictorySettings,
-  VictoryTheme,
   appendLinkIcon,
-  ecologyPlaygroundLoading
+  DatasetDropdown,
+  ecologyPlaygroundLoading,
+  Footer,
+  Header,
+  VictorySettings,
+  VictoryTheme
 };


### PR DESCRIPTION
This adds the dataset-dropdown component as a shared component that we can use across projects to add dataset-dropdowns inside of component playgrounds via ecology.

This also updates documentation with new functionality & adds default (non-breaking) props to the Header & Footer container.

cc @paulathevalley @coopy 