### PR TITLE
Victory Playground Bugs

### DIFF
--- a/src/markdown-renderers/ecology-playground-loading.js
+++ b/src/markdown-renderers/ecology-playground-loading.js
@@ -22,10 +22,10 @@ export default {
             <div class="lang-${escape(lang)}">
                 <span class="ecologyCode" style="display:none;">${escape(code)}</span>
                 <div class="Interactive">
-                    <div style="display: flex;flex-direction: row;flex-wrap: nowrap;align-items: stretch;justify-content: space-between;margin-left: -20px;padding: 0;">
-                        <div style="min-height:300px;display: flex;flex: 1 2 45%;margin: 0;">
+                    <div style="display: flex;flex-direction: column;flex-wrap: nowrap;margin-left: -20px;padding: 0;">
+                        <div style="display: flex;flex: 0 0 150px;margin: 0;">
                         </div>
-                        <div style="min-height:300px;display: flex;flex: 3 2 55%;margin: 0;padding: 0;">
+                        <div style="display: flex;flex: 0 0 150px;margin: 0;padding: 0;">
                             <div class="ReactCodeMirror playgroundStage"></div>
                         </div>
                     </div>

--- a/src/markdown-renderers/ecology-playground-loading.js
+++ b/src/markdown-renderers/ecology-playground-loading.js
@@ -25,7 +25,7 @@ export default {
                     <div style="display: flex;flex-direction: column;flex-wrap: nowrap;margin-left: -20px;padding: 0;">
                         <div style="display: flex;flex: 0 0 150px;margin: 0;">
                         </div>
-                        <div style="display: flex;flex: 0 0 150px;margin: 0;padding: 0;">
+                        <div style="display: flex;flex: 0 0 150px;margin: 0;padding: 0;background-color: #222;">
                             <div class="ReactCodeMirror playgroundStage"></div>
                         </div>
                     </div>

--- a/src/themes/victory-settings.js
+++ b/src/themes/victory-settings.js
@@ -35,6 +35,7 @@ export default {
   // Media Queries
   // ---------------------
   mediaQueries: {
+    small: "only screen and (max-width: 650px)",
     medium: "only screen and (min-width: 960px)",
     large: "only screen and (min-width: 1260px)"
   },

--- a/src/themes/victory.js
+++ b/src/themes/victory.js
@@ -287,22 +287,24 @@ export default {
   },
   ".Interactive .playground": {
     display: "flex",
-    flexDirection: "column",
+    flexDirection: "row",
     flexWrap: "wrap",
     padding: 0
   },
   ".Interactive .playgroundCode": {
-    flex: "0 0 100%",
+    flex: "0 0 45%",
     order: "2",
     margin: 0,
     padding: 0
   },
   ".Interactive .playgroundStage": {
     padding: `${settings.gutter}px ${settings.gutter}px`,
-    width: "100%"
+    height: "100%",
+    maxHeight: "400px",
+    overflow: "scroll"
   },
   ".Interactive .playgroundPreview": {
-    flex: "0 1 420px",
+    flex: "0 1 55%",
     order: "1",
     padding: `0 0 ${settings.gutter * 2}px 0`,
     position: "relative",
@@ -311,7 +313,7 @@ export default {
   ".Interactive .playgroundPreview > div:first-child": {
     // wrapper divs: the worst
     width: "100%",
-    maxHeight: "390px",
+    maxHeight: "320px",
     margin: "0 auto"
   },
   ".Interactive .previewArea, .Interactive .previewArea > div:first-child": {
@@ -320,12 +322,12 @@ export default {
     alignItems: "center",
     justifyContent: "center",
     minHeight: "100px",
-    maxHeight: "390px",
+    maxHeight: "320px",
     width: "100%",
     margin: "0 auto"
   },
   ".Interactive .playgroundPreview svg": {
-    maxHeight: "420px",
+    maxHeight: "inherit",
     margin: "0 auto"
   },
   ".Interactive .playgroundPreview:after": {
@@ -436,8 +438,11 @@ export default {
   **/
   mediaQueries: {
     [settings.mediaQueries.small]: {
-      ".Interactive .playgroundPreview": {
-        flex: "0 1 300px"
+      ".Interactive .playground": {
+        flexDirection: "column"
+      },
+      ".Interactive .previewArea, .Interactive .previewArea > div:first-child": {
+        flexBasis: "350px"
       }
     },
     [settings.mediaQueries.medium]: {
@@ -460,9 +465,6 @@ export default {
       },
       ".Main pre pre": {
         margin: 0
-      },
-      ".Interactive .playgroundPreview svg": {
-        maxHeight: "inherit"
       }
     },
     [settings.mediaQueries.large]: {

--- a/src/themes/victory.js
+++ b/src/themes/victory.js
@@ -263,10 +263,20 @@ export default {
    *          |- .playgroundPreview
    */
   ".Recipe .Interactive .playground": {
-    "flexDirection": "column"
+    flexDirection: "column"
+  },
+  ".Recipe .Interactive .playgroundPreview": {
+    flexBasis: "500px"
+  },
+  ".Recipe .Interactive .playgroundPreview > div:first-child, .Recipe .Interactive .previewArea, .Recipe .Interactive .previewArea > div:first-child": {
+    maxHeight: "initial !important"
+  },
+  ".Recipe .Interactive .playgroundStage": {
+    maxHeight: "initial",
+    minHeight: "200px"
   },
   ".Recipe .Interactive .playgroundCode": {
-    "flex": "none"
+    flex: "none"
   },
   /*
    * Interactive/Component Playground

--- a/src/themes/victory.js
+++ b/src/themes/victory.js
@@ -265,11 +265,11 @@ export default {
   ".Recipe .Interactive .playground": {
     flexDirection: "column"
   },
-  ".Recipe .Interactive .playgroundPreview": {
-    flexBasis: "500px"
-  },
   ".Recipe .Interactive .playgroundPreview > div:first-child, .Recipe .Interactive .previewArea": {
     maxHeight: "initial !important"
+  },
+  ".Recipe .Interactive .playgroundPreview": {
+    flexBasis: "500px"
   },
   ".Recipe .Interactive .previewArea > div:first-child": {
     maxHeight: "450px"
@@ -463,6 +463,12 @@ export default {
       },
       ".Interactive .playgroundStage": {
         maxHeight: "280px"
+      },
+      ".Recipe .Interactive .playgroundPreview": {
+        flexBasis: "400px"
+      },
+      ".Recipe .Interactive .previewArea > div:first-child": {
+        maxHeight: "350px"
       }
     },
     [settings.mediaQueries.medium]: {

--- a/src/themes/victory.js
+++ b/src/themes/victory.js
@@ -268,8 +268,11 @@ export default {
   ".Recipe .Interactive .playgroundPreview": {
     flexBasis: "500px"
   },
-  ".Recipe .Interactive .playgroundPreview > div:first-child, .Recipe .Interactive .previewArea, .Recipe .Interactive .previewArea > div:first-child": {
+  ".Recipe .Interactive .playgroundPreview > div:first-child, .Recipe .Interactive .previewArea": {
     maxHeight: "initial !important"
+  },
+  ".Recipe .Interactive .previewArea > div:first-child": {
+    maxHeight: "450px"
   },
   ".Recipe .Interactive .playgroundStage": {
     maxHeight: "initial",

--- a/src/themes/victory.js
+++ b/src/themes/victory.js
@@ -287,7 +287,7 @@ export default {
   },
   ".Interactive .playground": {
     display: "flex",
-    flexDirection: "row",
+    flexDirection: "column",
     flexWrap: "wrap",
     padding: 0
   },
@@ -302,15 +302,30 @@ export default {
     width: "100%"
   },
   ".Interactive .playgroundPreview": {
-    flex: "0 0 100%",
+    flex: "0 1 420px",
     order: "1",
-    marginBottom: 0,
     padding: `0 0 ${settings.gutter * 2}px 0`,
     position: "relative",
     textAlign: "center"
   },
+  ".Interactive .playgroundPreview > div:first-child": {
+    // wrapper divs: the worst
+    width: "100%",
+    maxHeight: "390px",
+    margin: "0 auto"
+  },
+  ".Interactive .previewArea, .Interactive .previewArea > div:first-child": {
+    // wrapper divs: the _actual_ worst
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    minHeight: "100px",
+    maxHeight: "390px",
+    width: "100%",
+    margin: "0 auto"
+  },
   ".Interactive .playgroundPreview svg": {
-    maxHeight: "450px",
+    maxHeight: "420px",
     margin: "0 auto"
   },
   ".Interactive .playgroundPreview:after": {
@@ -400,10 +415,31 @@ export default {
     fontFamily: settings.monospace,
     color: settings.paleMud
   },
+  ".Interactive .previewArea .playgroundDatasetSelectWrapper": {
+    display: "flex",
+    alignItems: "center",
+    position: "absolute",
+    right: "10px",
+    top: "10px"
+  },
+  ".Interactive .previewArea .playgroundDatasetSelect": {
+    border: `1px solid ${settings.paleSand}`,
+    fontSize: "14px"
+  },
+  ".Interactive .previewArea .playgroundDatasetSelectLabel": {
+    fontSize: "14px",
+    marginRight: "5px",
+    lineHeight: 1.4
+  },
   /*
    * Media Queries
   **/
   mediaQueries: {
+    [settings.mediaQueries.small]: {
+      ".Interactive .playgroundPreview": {
+        flex: "0 1 300px"
+      }
+    },
     [settings.mediaQueries.medium]: {
       body: {
         fontSize: "20px",
@@ -427,25 +463,6 @@ export default {
       },
       ".Interactive .playgroundPreview svg": {
         maxHeight: "inherit"
-      },
-      ".Interactive .playgroundPreview > div:first-child": {
-        // wrapper divs: the worst
-        width: "100%",
-        margin: "0 auto",
-        maxHeight: "450px"
-      },
-      ".Interactive .previewArea, .Interactive .previewArea > div:first-child": {
-        // wrapper divs: the _actual_ worst
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        width: "100%",
-        margin: "0 auto",
-        minHeight: "100px",
-        maxHeight: "450px"
-      },
-      ".Interactive .playgroundPreview": {
-        flex: "0 1 500px"
       }
     },
     [settings.mediaQueries.large]: {
@@ -480,19 +497,6 @@ export default {
         margin: 0,
         padding: 0
       },
-      ".Interactive .playgroundPreview": {
-        display: "flex",
-        flex: "1 2 45%",
-        margin: 0,
-        padding: `${settings.gutter}px ${settings.gutter * 4}px ${settings.gutter}px`
-      },
-      ".Interactive .playgroundPreview svg": {
-        maxHeight: "inherit"
-      },
-      ".Interactive .playgroundPreview > div:first-child": {
-        // wrapper divs: the worst
-        width: "100%"
-      },
       ".Interactive .playgroundError": {
         margin: 0,
         padding: `${settings.gutter}px ${settings.gutter * 2}px`,
@@ -504,23 +508,6 @@ export default {
       },
       ".Recipe .Interactive .playground": {
         marginLeft: 0
-      },
-      ".playgroundsMaxHeight .Interactive .playgroundStage": {
-        maxHeight: "500px",
-        overflowY: "scroll"
-      },
-      ".playgroundsMaxHeight .Interactive .playgroundPreview": {
-        maxHeight: "500px"
-      },
-      ".playgroundsMaxHeight .Interactive .playgroundPreview > div:first-child": {
-        // wrapper divs: the worst
-        margin: "0 auto",
-        maxHeight: "400px"
-      },
-      ".playgroundsMaxHeight .Interactive .previewArea, .playgroundsMaxHeight .Interactive .previewArea > div:first-child": {
-        // wrapper divs: the worst
-        margin: "0 auto",
-        maxHeight: "400px"
       }
     }
   },

--- a/src/themes/victory.js
+++ b/src/themes/victory.js
@@ -438,9 +438,13 @@ export default {
         maxHeight: "450px"
       },
       ".Interactive .previewArea, .Interactive .previewArea > div:first-child": {
-        // wrapper divs: the worst
+        // wrapper divs: the _actual_ worst
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
         width: "100%",
         margin: "0 auto",
+        minHeight: "100px",
         maxHeight: "450px"
       },
       ".Interactive .playgroundPreview": {

--- a/src/themes/victory.js
+++ b/src/themes/victory.js
@@ -265,8 +265,11 @@ export default {
   ".Recipe .Interactive .playground": {
     flexDirection: "column"
   },
-  ".Recipe .Interactive .playgroundPreview > div:first-child, .Recipe .Interactive .previewArea": {
+  ".Recipe .Interactive .playgroundPreview > div:first-child": {
     maxHeight: "initial !important"
+  },
+  ".Recipe .Interactive .previewArea": {
+    maxHeight: "500px"
   },
   ".Recipe .Interactive .playgroundPreview": {
     flexBasis: "500px"
@@ -295,7 +298,6 @@ export default {
   ".Interactive": {
     background: settings.whiteSand,
     margin: `${settings.gutter}px 0 ${settings.gutter * 2}px`,
-    minHeight: "150px",
     width: "100%"
   },
   ".Interactive .playground": {
@@ -308,7 +310,8 @@ export default {
     flex: "0 0 45%",
     order: "2",
     margin: 0,
-    padding: 0
+    padding: 0,
+    backgroundColor: settings.codeMirror.bg
   },
   ".Interactive .playgroundStage": {
     padding: `${settings.gutter}px ${settings.gutter}px`,
@@ -330,7 +333,7 @@ export default {
     maxHeight: "320px",
     margin: "0 auto"
   },
-  ".Interactive .previewArea, .Interactive .previewArea > div:first-child": {
+  ".Interactive .previewArea": {
     // wrapper divs: the _actual_ worst
     display: "flex",
     alignItems: "center",
@@ -455,8 +458,11 @@ export default {
       ".Interactive .playground": {
         flexDirection: "column"
       },
+      ".Interactive .playgroundPreview": {
+        flexBasis: "300px"
+      },
       ".Interactive .previewArea, .Interactive .previewArea > div:first-child": {
-        flexBasis: "350px"
+        flexBasis: "250px"
       },
       ".Interactive .playgroundCode": {
         flex: "auto"
@@ -466,9 +472,6 @@ export default {
       },
       ".Recipe .Interactive .playgroundPreview": {
         flexBasis: "400px"
-      },
-      ".Recipe .Interactive .previewArea > div:first-child": {
-        maxHeight: "350px"
       }
     },
     [settings.mediaQueries.medium]: {

--- a/src/themes/victory.js
+++ b/src/themes/victory.js
@@ -445,6 +445,9 @@ export default {
       ".Interactive .previewArea, .Interactive .previewArea > div:first-child": {
         flexBasis: "350px"
       },
+      ".Interactive .playgroundCode": {
+        flex: "auto"
+      },
       ".Interactive .playgroundStage": {
         maxHeight: "280px"
       }

--- a/src/themes/victory.js
+++ b/src/themes/victory.js
@@ -299,6 +299,7 @@ export default {
   },
   ".Interactive .playgroundStage": {
     padding: `${settings.gutter}px ${settings.gutter}px`,
+    width: "100%",
     height: "100%",
     maxHeight: "400px",
     overflow: "scroll"
@@ -443,6 +444,9 @@ export default {
       },
       ".Interactive .previewArea, .Interactive .previewArea > div:first-child": {
         flexBasis: "350px"
+      },
+      ".Interactive .playgroundStage": {
+        maxHeight: "280px"
       }
     },
     [settings.mediaQueries.medium]: {

--- a/src/themes/victory.js
+++ b/src/themes/victory.js
@@ -268,9 +268,6 @@ export default {
   ".Recipe .Interactive .playgroundCode": {
     "flex": "none"
   },
-  ".Recipe .Interactive .playgroundPreview": {
-    "flex": "none"
-  },
   /*
    * Interactive/Component Playground
    * .Interactive
@@ -448,7 +445,7 @@ export default {
         maxHeight: "450px"
       },
       ".Interactive .playgroundPreview": {
-        maxHeight: "500px"
+        flex: "0 1 500px"
       }
     },
     [settings.mediaQueries.large]: {


### PR DESCRIPTION
#### Issues:
1. When the page has loaded, but before component playground does its thing, the code block is a tiny, unappealing textarea (Fixed byhttps://github.com/FormidableLabs/victory-examples/pull/36 )
2. When component-playground has initialized, the Figure is halfway intruding on the code block.
3. When resizing the window, glitchy things happen

https://files.slack.com/files-pri/T02913TEC-F1T67UC91/victory-recipe-doodoo.gif

#### Fixes/Changes:
1. Victory Animation example exceeding container by displaying the items as flex
![screen shot 2016-07-19 at 2 23 51 pm](https://cloud.githubusercontent.com/assets/1633837/16967207/c54df3f2-4dbc-11e6-84cc-401abf76a340.png)
2. Fixes figure intruding on codeblock by defining a sensible flex-basis and setting the SVG to a maxheight in order to contain it
3. Fixed breakpoints that caused resizing glitches to occur
4. Make default loading of components vertically-stacked
5. Add styles for dataset-select dropdown