### PR TITLE
Style gist/clipboard buttons

### DIFF
--- a/src/themes/victory.js
+++ b/src/themes/victory.js
@@ -296,11 +296,14 @@ export default {
    *          |- .previewArea
    */
   ".Interactive": {
+    position: "relative",
     background: settings.whiteSand,
     margin: `${settings.gutter}px 0 ${settings.gutter * 2}px`,
     width: "100%"
   },
   ".Interactive .playground": {
+    position: "relative",
+    zIndex: 1,
     display: "flex",
     flexDirection: "row",
     flexWrap: "wrap",
@@ -451,6 +454,34 @@ export default {
     lineHeight: 1.4
   },
   /*
+   * Component Playground Export/Copy Buttons
+   * .Interactive
+   * |- .Toolbar
+   *    |- button.Button-GistExport
+   *    |- button.Button-Clipboard
+   */
+  ".Interactive .Toolbar": {
+    position: "absolute",
+    zIndex: 2,
+    right: "0px",
+    top: "0px",
+    padding: "10px 5px"
+  },
+  ".Interactive .Toolbar button": {
+    margin: "0px 2.5px",
+    border: `1px solid ${settings.darkerSand}`,
+    borderRadius: "1px",
+    backgroundColor: "transparent",
+    fontFamily: settings.monospace,
+    fontSize: "9px",
+    color: settings.darkerSand,
+    cursor: "Pointer"
+  },
+  ".Interactive .Toolbar button:hover": {
+    backgroundColor: settings.darkerSand,
+    color: settings.codeMirror.bg
+  },
+  /*
    * Media Queries
   **/
   mediaQueries: {
@@ -472,6 +503,18 @@ export default {
       },
       ".Recipe .Interactive .playgroundPreview": {
         flexBasis: "400px"
+      },
+      ".Interactive .Toolbar": {
+        position: "relative"
+      },
+      ".Interactive .Toolbar button": {
+        border: `1px solid ${settings.sand}`,
+        fontSize: "11px",
+        color: settings.sand
+      },
+      ".Interactive .Toolbar button:hover": {
+        backgroundColor: settings.sand,
+        color: settings.whiteSand
       }
     },
     [settings.mediaQueries.medium]: {

--- a/src/themes/victory.js
+++ b/src/themes/victory.js
@@ -5,6 +5,11 @@
 // Settings
 import settings from "./victory-settings";
 
+const playgroundSettings = {
+  recipePlaygroundHeight: "400px",
+  playgroundHeight: "360px"
+};
+
 // Stylesheet
 export default {
   /*
@@ -186,7 +191,7 @@ export default {
     marginTop: "0.25em"
   },
   ".Ecology ul > li:before": {
-    content: "''",
+    content: "",
     width: "1em",
     height: "1em",
     display: "block",
@@ -320,7 +325,7 @@ export default {
     padding: `${settings.gutter}px ${settings.gutter}px`,
     width: "100%",
     height: "100%",
-    maxHeight: "400px",
+    maxHeight: playgroundSettings.playgroundHeight,
     overflow: "scroll"
   },
   ".Interactive .playgroundPreview": {
@@ -462,10 +467,12 @@ export default {
    */
   ".Interactive .Toolbar": {
     position: "absolute",
+    display: "flex",
     zIndex: 2,
     right: "0px",
     top: "0px",
-    padding: "10px 5px"
+    padding: "0px 5px",
+    margin: "7.5px 0px"
   },
   ".Interactive .Toolbar button": {
     margin: "0px 2.5px",
@@ -481,6 +488,10 @@ export default {
     backgroundColor: settings.darkerSand,
     color: settings.codeMirror.bg
   },
+  // Add padding when toolbar buttons are visible
+  ".Interactive .Toolbar ~ .playground .playgroundStage": {
+    paddingTop: "30px"
+  },
   /*
    * Media Queries
   **/
@@ -490,7 +501,7 @@ export default {
         flexDirection: "column"
       },
       ".Interactive .playgroundPreview": {
-        flexBasis: "300px"
+        flexBasis: playgroundSettings.playgroundHeight
       },
       ".Interactive .previewArea, .Interactive .previewArea > div:first-child": {
         flexBasis: "250px"
@@ -499,13 +510,16 @@ export default {
         flex: "auto"
       },
       ".Interactive .playgroundStage": {
-        maxHeight: "280px"
+        maxHeight: "340px"
       },
       ".Recipe .Interactive .playgroundPreview": {
-        flexBasis: "400px"
+        flexBasis: playgroundSettings.recipePlaygroundHeight
       },
       ".Interactive .Toolbar": {
-        position: "relative"
+        top: playgroundSettings.playgroundHeight
+      },
+      ".Recipe .Interactive .Toolbar": {
+        top: playgroundSettings.recipePlaygroundHeight
       },
       ".Interactive .Toolbar button": {
         border: `1px solid ${settings.sand}`,


### PR DESCRIPTION
Adding styles for the buttons to export to gist & save to clipboard. The links are outlines that become solid when hovered.

Will need to add the props to the various victory repositories.

Closes https://github.com/FormidableLabs/victory-docs/issues/29
![screen shot 2016-07-25 at 9 38 30 am](https://cloud.githubusercontent.com/assets/1633837/17109218/f48a2c10-524b-11e6-8267-71dc94a8063b.png)
![screen shot 2016-07-25 at 9 39 47 am](https://cloud.githubusercontent.com/assets/1633837/17109217/f4856a86-524b-11e6-9ccf-42b65d5d4132.png)

