### PR TITLE
Use latest version of radium

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "babel-preset-es2015-webpack": "^6.4.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-1": "^6.5.0",
-    "radium": "^0.17.1",
+    "radium": "^0.18.1",
     "react": "^15.1.0",
     "rimraf": "^2.4.4"
   },


### PR DESCRIPTION
This should silence the warnings being generated by the Header & Footer component that are using Radium to generate styles