### PR TITLE
Fix Dropdown Spacing, Mobile Playground Issues

### DIFF
--- a/src/themes/victory.js
+++ b/src/themes/victory.js
@@ -449,6 +449,9 @@ export default {
     right: "10px",
     top: "10px"
   },
+  ".Interactive .previewArea .playgroundDatasetSelectWrapper ~ *": {
+    marginTop: "40px"
+  },
   ".Interactive .previewArea .playgroundDatasetSelect": {
     border: `1px solid ${settings.paleSand}`,
     fontSize: "14px"

--- a/src/themes/victory.js
+++ b/src/themes/victory.js
@@ -267,7 +267,7 @@ export default {
    *          |- .playgroundCode
    *          |- .playgroundPreview
    */
-  ".Recipe .Interactive .playground": {
+".Recipe .Interactive .playground": {
     flexDirection: "column"
   },
   ".Recipe .Interactive .playgroundPreview > div:first-child": {
@@ -311,7 +311,7 @@ export default {
     zIndex: 1,
     display: "flex",
     flexDirection: "row",
-    flexWrap: "wrap",
+    flexWrap: "nowrap",
     padding: 0
   },
   ".Interactive .playgroundCode": {
@@ -554,9 +554,6 @@ export default {
       },
       ".Main pre pre": {
         margin: 0
-      },
-      ".Interactive .playground": {
-        flexWrap: "nowrap"
       }
     },
     [settings.mediaQueries.large]: {
@@ -579,7 +576,6 @@ export default {
         lineHeight: 1.2
       },
       ".Interactive .playground": {
-        flexWrap: "nowrap",
         alignItems: "stretch",
         justifyContent: "space-between",
         marginLeft: `${settings.gutter * -1}px`,

--- a/src/themes/victory.js
+++ b/src/themes/victory.js
@@ -554,6 +554,9 @@ export default {
       },
       ".Main pre pre": {
         margin: 0
+      },
+      ".Interactive .playground": {
+        flexWrap: "nowrap"
       }
     },
     [settings.mediaQueries.large]: {


### PR DESCRIPTION
This PR will:
- Add spacing between playground rendered components that contain dropdowns
- Fix the mobile breakpoint issue present at 650px

cc @paulathevalley @bmathews 

Before:
![screen shot 2016-08-08 at 9 12 40 pm](https://cloud.githubusercontent.com/assets/1633837/17504361/230bbac4-5dad-11e6-93c3-e3e5bcf126b0.png)

After:
![screen shot 2016-08-08 at 9 13 07 pm](https://cloud.githubusercontent.com/assets/1633837/17504360/230987d6-5dad-11e6-93b5-7e37e656b56a.png)
