### PR TITLE
adding an outline of the content components for oss projects

### DIFF
--- a/CONTENT.md
+++ b/CONTENT.md
@@ -1,0 +1,86 @@
+# Content Components for Formidable Landers
+
+## Flagship Projects
+*Includes Victory, Spectacle, Radium, and Builder*
+
+Flagship projects have slightly more content, and have their own individual product brand and design.
+
+All flagship projects include the universal nav and footer.
+
+### Home
+
+* Logo/Title
+
+* Tagline
+
+* ```npm install```
+
+* Link to Getting Started Guide (prominent)
+
+* Link to FAQ guide (prominent)
+
+* Feature List (why use this over other offerings? value adds)
+
+* Link to source code and link to github issues or gitter channel
+
+* Project in use w/ link to showcase if applicable
+
+### Docs
+
+* Getting Started Guide
+This can be a installation walkthrough or a tutorial, the more detailed the better.
+
+* Contributing (either a page in the docs site or a link to a contributing file in the repo)
+
+* FAQ
+
+* API docs/feature docs (can be split into sub-sections if lengthy)
+
+* Examples/recipes
+
+### About
+
+* Showcase if applicable
+
+* Blurb about the project
+
+* Link to contributors page in Github
+
+* Blurb about Formidable
+
+## General Open Source Projects
+
+Non-flagship projects follow a design template to keep things quick and easy when booting up a new docs site for an emerging project.
+
+All non-flagship projects include the universal nav and footer.
+
+### Home
+
+* Logo/Title
+
+* Tagline
+
+* ```npm install```
+
+* Feature List (why use this over other offerings? value adds)
+
+* Prominent link to docs/getting started
+
+### Docs
+
+Docs can all live on a single page if they are short enough for that to make sense.
+
+* Getting Started Guide or Install Guide
+This can be a installation walkthrough or a tutorial, the more detailed the better.
+
+* Contributing (either a page in the docs site or a link to a contributing file in the repo)
+
+* API docs/feature docs (can be split into sub-sections if lengthy)
+
+### About
+
+* Short blurb about the project
+
+* Link to contributors page in Github
+
+* Blurb about Formidable


### PR DESCRIPTION
This adds a markdown file outlining what the content components should generally look like for both flagship and non-flagship projects.

cc/ @paulathevalley 