### PR TITLE
Fix typo in font name

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -7,7 +7,7 @@
   <title>HQ of Formidable Landers</title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-  <link rel="stylesheet" type="text/css" href="https://formidable.com/wp-content/themes/formidable/assets/css/fonts.min.css" />
+  <link href="//formidable.com/open-source/fonts.css" rel="stylesheet" type="text/css">
 </head>
 <body>
   <!--[if lt IE 8]>

--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -49,7 +49,7 @@ class Footer extends React.Component {
       },
       ".default": {
         marginTop: "16px", /* Align baseline of logo with baseline of link text */
-        fontFamily: `"akkurta", "Inconsolata", monospace`,
+        fontFamily: `"akkurat", "Inconsolata", monospace`,
         fontSize: "13px"
       },
       ".default a": {

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -47,7 +47,7 @@ class Header extends React.Component {
       },
       ".default": {
         marginTop: "16px", /* Align baseline of logo with baseline of link text */
-        fontFamily: `"akkurta", "Inconsolata", monospace`,
+        fontFamily: `"akkurat", "Inconsolata", monospace`,
         fontSize: "13px",
         letterSpacing: "0.15em",
         textTransform: "uppercase"


### PR DESCRIPTION
- Fix typo in font name (should be akkurat not akkurta) 
- Upload minified fonts.css with font families: `"akkurat"`, `"sharp"`, and `"tiempos"` (Resolves first part of https://github.com/FormidableLabs/formidable-landers/issues/162)

/cc @kylecesmat 