### PR TITLE
Fix logo overflow on header on narrow screen sizes

### DIFF
--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -42,7 +42,7 @@ class Footer extends React.Component {
         textDecoration: "none",
         transition: "color 250ms ease-in, fill 300ms ease-in"
       },
-      "a:visited": {
+      "a:visited": { /* Necessary to retain link order in <Style /> */
       },
       "a:hover, a:focus": {
         transition: "color 400ms ease-out, fill 500ms ease-out"
@@ -55,11 +55,12 @@ class Footer extends React.Component {
       ".default a": {
         display: "inline-block",
         letterSpacing: "0.15em",
-        marginLeft: "2em",
+        lineHeight: 2,
+        marginRight: "2em",
         textTransform: "uppercase"
       },
-      ".default a:first-child": {
-        marginLeft: 0
+      ".default a:last-child": {
+        marginRight: 0
       },
       ".default:last-child": { /* Target the trademark */
         flex: "0 0 100%",
@@ -148,7 +149,7 @@ Footer.propTypes = {
 
 const defaultFooterChildren =
   <div className="default">
-    <a href="https://formidable.com/contact/">Contact us</a>
+    <a href="https://formidable.com/contact/">Contact</a>
     <a href="https://formidable.com/careers/">Careers</a>
     <a href="https://twitter.com/FormidableLabs">Twitter</a>
     <a href="https://github.com/FormidableLabs/">Github</a>

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -40,7 +40,7 @@ class Header extends React.Component {
         textDecoration: "none",
         transition: "color 250ms ease-in, fill 300ms ease-in"
       },
-      "a:visited": {
+      "a:visited": { /* Necessary to retain link order in <Style /> */
       },
       "a:hover, a:focus": {
         transition: "color 400ms ease-out, fill 500ms ease-out"
@@ -50,6 +50,7 @@ class Header extends React.Component {
         fontFamily: `"akkurat", "Inconsolata", monospace`,
         fontSize: "13px",
         letterSpacing: "0.15em",
+        lineHeight: 2,
         textTransform: "uppercase"
       },
       ".default *": {
@@ -110,7 +111,8 @@ class Header extends React.Component {
         <div
           style={{
             height: "50px",
-            marginRight: "auto"
+            marginRight: "auto",
+            overflow: "hidden"
           }}
         >
           <a


### PR DESCRIPTION
Fix bug where logo in header was exceeding the width of narrow screen sizes. 

screenshot:
![screen shot 2016-09-08 at 12 59 03 pm](https://cloud.githubusercontent.com/assets/768965/18364784/7ecdcf80-75c4-11e6-81d9-17a5c9ca3981.png)

