### PR TITLE
Fix style ordering, add container wrapper

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -25,7 +25,7 @@ class Demo extends React.Component {
     const trademark = <div className="default">Formidable Labs, Inc. has several trademarks.</div>;
     return (
       <div style={styles.demo}>
-        <Header containerStyle={{margin: "0 auto", maxWidth: "640px"}} padding="2px" />
+        <Header containerStyle={{margin: "0 auto", maxWidth: "640px"}} padding="24px" />
         <Header theme="dark">
           <div
             className="default" /* This default class will match the Formidable branding. */

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -25,7 +25,7 @@ class Demo extends React.Component {
     const trademark = <div className="default">Formidable Labs, Inc. has several trademarks.</div>;
     return (
       <div style={styles.demo}>
-        <Header />
+        <Header containerStyle={{margin: "0 auto", maxWidth: "640px"}} padding="2px" />
         <Header theme="dark">
           <div
             className="default" /* This default class will match the Formidable branding. */

--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -41,6 +41,9 @@ class Footer extends React.Component {
 
   getClassStyles(theme) {
     const base = {
+      "svg": {
+        fill: "currentColor"
+      },
       "a:link": {
         textDecoration: "none",
         transition: "color 250ms ease-in, fill 300ms ease-in"
@@ -73,30 +76,24 @@ class Footer extends React.Component {
     };
     const dark = {
       "a:link": {
-        color: "#fff",
-        fill: "#fff"
+        color: "#fff"
       },
       "a:visited": {
-        color: "#e7e5e3",
-        fill: "#e7e5e3"
+        color: "#e7e5e3"
       },
       "a:hover, a:focus": {
-        color: "#e58c7d",
-        fill: "#c43a31"
+        color: "#dc7a6b"
       }
     };
     const light = {
       "a:link": {
-        color: "#242121",
-        fill: "#242121"
+        color: "#242121"
       },
       "a:visited": {
-        color: "#242121",
-        fill: "#242121"
+        color: "#242121"
       },
       "a:hover, a:focus": {
-        color: "#c43a31",
-        fill: "#c43a31"
+        color: "#c43a31"
       }
     };
 
@@ -111,18 +108,18 @@ class Footer extends React.Component {
     const classStyles = this.getClassStyles(this.props.theme);
     return (
       <footer
-        className="formidable-footer"
+        className="formidableFooter"
         style={[
           styles.base,
           this.props.theme && styles[this.props.theme],
           this.props.style && styles.style
         ]}>
         <Style
-          scopeSelector=".formidable-footer"
+          scopeSelector=".formidableFooter"
           rules={classStyles}
         />
         <div
-          className="container"
+          className="formidableFooter-container"
           style={[
             styles.container,
             this.props.containerStyle && styles.containerStyle

--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -9,6 +9,9 @@ class Footer extends React.Component {
   getStyles() {
     return {
       base: {
+        margin: "2rem 0 0 0"
+      },
+      container: {
         // Lipstick
         fontFamily: "inherit",
         fontSize: "inherit",
@@ -19,7 +22,6 @@ class Footer extends React.Component {
         flexDirection: "row",
         flexWrap: "wrap",
         justifyContent: "flex-end",
-        margin: "2rem 0 0 0",
         padding: this.props.padding
       },
       dark: {
@@ -32,7 +34,8 @@ class Footer extends React.Component {
         background: "#ffffff",
         color: "#242121"
       },
-      style: this.props.style
+      style: this.props.style,
+      containerStyle: this.props.containerStyle
     };
   }
 
@@ -111,29 +114,37 @@ class Footer extends React.Component {
         className="formidable-footer"
         style={[
           styles.base,
-          this.props.style && styles.style,
-          this.props.theme && styles[this.props.theme]
+          this.props.theme && styles[this.props.theme],
+          this.props.style && styles.style
         ]}>
         <Style
           scopeSelector=".formidable-footer"
           rules={classStyles}
         />
-        {this.props.children}
         <div
-          style={{
-            height: "50px",
-            margin: "0 0 0 auto",
-            overflow: "hidden"
-          }}
+          className="container"
+          style={[
+            styles.container,
+            this.props.containerStyle && styles.containerStyle
+          ]}
         >
-          <a
-            href="https://formidable.com/"
-            style={{ display: "flex", height: "inherit" }}
-            target="_blank"
-            dangerouslySetInnerHTML={{ __html: LOGO }}
-          />
+          {this.props.children}
+          <div
+            style={{
+              height: "50px",
+              margin: "0 0 0 auto",
+              overflow: "hidden"
+            }}
+          >
+            <a
+              href="https://formidable.com/"
+              style={{ display: "flex", height: "inherit" }}
+              target="_blank"
+              dangerouslySetInnerHTML={{ __html: LOGO }}
+            />
+          </div>
+          {this.props.trademark}
         </div>
-        {this.props.trademark}
       </footer>
     );
   }
@@ -141,6 +152,7 @@ class Footer extends React.Component {
 
 Footer.propTypes = {
   children: React.PropTypes.node,
+  containerStyle: React.PropTypes.object,
   padding: React.PropTypes.string,
   style: React.PropTypes.object,
   trademark: React.PropTypes.node,
@@ -157,6 +169,7 @@ const defaultFooterChildren =
 
 Footer.defaultProps = {
   children: defaultFooterChildren,
+  containerStyle: null,
   padding: "5rem 0 6rem",
   style: null,
   theme: "dark",

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -39,6 +39,9 @@ class Header extends React.Component {
 
   getClassStyles(theme) {
     const base = {
+      "svg": {
+        fill: "currentColor"
+      },
       "a:link": {
         textDecoration: "none",
         transition: "color 250ms ease-in, fill 300ms ease-in"
@@ -63,30 +66,24 @@ class Header extends React.Component {
     };
     const dark = {
       "a:link": {
-        color: "#fff",
-        fill: "#fff"
+        color: "#fff"
       },
       "a:visited": {
-        color: "#e7e5e3",
-        fill: "#e7e5e3"
+        color: "#e7e5e3"
       },
       "a:hover, a:focus": {
-        color: "#e58c7d",
-        fill: "#c43a31"
+        color: "#dc7a6b"
       }
     };
     const light = {
       "a:link": {
-        color: "#242121",
-        fill: "#242121"
+        color: "#242121"
       },
       "a:visited": {
-        color: "#242121",
-        fill: "#242121"
+        color: "#242121"
       },
       "a:hover, a:focus": {
-        color: "#c43a31",
-        fill: "#c43a31"
+        color: "#c43a31"
       }
     };
 
@@ -101,18 +98,18 @@ class Header extends React.Component {
     const classStyles = this.getClassStyles(this.props.theme);
     return (
       <header
-        className="formidable-header"
+        className="formidableHeader"
         style={[
           styles.base,
           this.props.theme && styles[this.props.theme],
           this.props.style && styles.style
         ]}>
         <Style
-          scopeSelector=".formidable-header"
+          scopeSelector=".formidableHeader"
           rules={classStyles}
         />
         <div
-          className="container"
+          className="formidableHeader-container"
           style={[
             styles.container,
             this.props.containerStyle && styles.containerStyle

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -9,6 +9,9 @@ class Header extends React.Component {
   getStyles() {
     return {
       base: {
+        margin: 0
+      },
+      container: {
         // Lipstick
         fontFamily: "inherit",
         fontSize: "inherit",
@@ -19,7 +22,6 @@ class Header extends React.Component {
         flexDirection: "row",
         flexWrap: "wrap",
         justifyContent: "center",
-        margin: 0,
         padding: this.props.padding
       },
       dark: {
@@ -30,7 +32,8 @@ class Header extends React.Component {
         // Light Theme
         background: "#ffffff"
       },
-      style: this.props.style
+      style: this.props.style,
+      containerStyle: this.props.containerStyle
     };
   }
 
@@ -101,28 +104,36 @@ class Header extends React.Component {
         className="formidable-header"
         style={[
           styles.base,
-          this.props.style && styles.style,
-          this.props.theme && styles[this.props.theme]
+          this.props.theme && styles[this.props.theme],
+          this.props.style && styles.style
         ]}>
         <Style
           scopeSelector=".formidable-header"
           rules={classStyles}
         />
         <div
-          style={{
-            height: "50px",
-            marginRight: "auto",
-            overflow: "hidden"
-          }}
+          className="container"
+          style={[
+            styles.container,
+            this.props.containerStyle && styles.containerStyle
+          ]}
         >
-          <a
-            href="https://formidable.com/open-source/"
-            target="_blank"
-            style={{ display: "flex", height: "inherit" }}
-            dangerouslySetInnerHTML={{ __html: LOGO_OSS }}
-          />
+          <div
+            style={{
+              height: "50px",
+              marginRight: "auto",
+              overflow: "hidden"
+            }}
+          >
+            <a
+              href="https://formidable.com/open-source/"
+              target="_blank"
+              style={{ display: "flex", height: "inherit" }}
+              dangerouslySetInnerHTML={{ __html: LOGO_OSS }}
+            />
+          </div>
+          {this.props.children}
         </div>
-        {this.props.children}
       </header>
     );
   }
@@ -130,9 +141,10 @@ class Header extends React.Component {
 
 Header.propTypes = {
   children: React.PropTypes.node,
+  containerStyle: React.PropTypes.object,
+  padding: React.PropTypes.string,
   style: React.PropTypes.object,
-  theme: React.PropTypes.oneOf(["light", "dark"]),
-  padding: React.PropTypes.string
+  theme: React.PropTypes.oneOf(["light", "dark"])
 };
 
 const defaultHeaderChildren =
@@ -143,9 +155,10 @@ const defaultHeaderChildren =
 
 Header.defaultProps = {
   children: defaultHeaderChildren,
+  containerStyle: null,
+  padding: "1.5rem 0",
   style: null,
-  theme: "dark",
-  padding: "1.5rem 0"
+  theme: "dark"
 };
 
 export default Radium(Header); //eslint-disable-line new-cap

--- a/test/src/components/footer.spec.js
+++ b/test/src/components/footer.spec.js
@@ -59,7 +59,7 @@ describe("Footer", () => {
     });
 
     it("accepts a custom message", () => {
-      const footer = shallow(<Footer>Formidable means “wonderful” in French. Do we look French to you?</Footer>);
+      const footer = shallow(<Footer>Formidable means “wonderful” in French. Do we look French to you?</Footer>).find(".container");
       expect(footer.props().children).to.contain("Formidable means “wonderful” in French. Do we look French to you?");
     });
   });

--- a/test/src/components/footer.spec.js
+++ b/test/src/components/footer.spec.js
@@ -27,8 +27,7 @@ describe("Footer", () => {
       const darkThemeLinkStyles = {
         textDecoration: "none",
         transition: "color 250ms ease-in, fill 300ms ease-in",
-        color: "#fff",
-        fill: "#fff"
+        color: "#fff"
       };
       expect(footerStyle.props().rules).to.have.property("a:link").that.deep.equals(darkThemeLinkStyles);
     });
@@ -59,7 +58,7 @@ describe("Footer", () => {
     });
 
     it("accepts a custom message", () => {
-      const footer = shallow(<Footer>Formidable means “wonderful” in French. Do we look French to you?</Footer>).find(".container");
+      const footer = shallow(<Footer>Formidable means “wonderful” in French. Do we look French to you?</Footer>).find(".formidableFooter-container");
       expect(footer.props().children).to.contain("Formidable means “wonderful” in French. Do we look French to you?");
     });
   });

--- a/test/src/components/header.spec.js
+++ b/test/src/components/header.spec.js
@@ -68,8 +68,8 @@ describe("Header", () => {
 
   describe("props", () => {
     it("accepts custom padding", () => {
-      const headerLink = shallow(<Header padding="20px 20px" />);
-      expect(headerLink.props().style).to.have.property("padding", "20px 20px");
+      const headerContainer = shallow(<Header padding="20px 20px" />).find(".container");
+      expect(headerContainer.props().style).to.have.property("padding", "20px 20px");
     });
 
     it("can change to light theme", () => {

--- a/test/src/components/header.spec.js
+++ b/test/src/components/header.spec.js
@@ -27,8 +27,7 @@ describe("Header", () => {
       const darkThemeLinkStyles = {
         textDecoration: "none",
         transition: "color 250ms ease-in, fill 300ms ease-in",
-        color: "#fff",
-        fill: "#fff"
+        color: "#fff"
       };
       expect(headerStyle.props().rules).to.have.property("a:link").that.deep.equals(darkThemeLinkStyles);
     });
@@ -68,15 +67,14 @@ describe("Header", () => {
 
   describe("props", () => {
     it("accepts custom padding", () => {
-      const headerContainer = shallow(<Header padding="20px 20px" />).find(".container");
+      const headerContainer = shallow(<Header padding="20px 20px" />).find(".formidableHeader-container");
       expect(headerContainer.props().style).to.have.property("padding", "20px 20px");
     });
 
     it("can change to light theme", () => {
       const headerStyle = shallow(<Header theme="light" />).find("Style");
       const lightVisitedLinkStyles = {
-        color: "#242121",
-        fill: "#242121"
+        color: "#242121"
       };
       expect(headerStyle.props().rules).to.have.property("a:visited").that.deep.equals(lightVisitedLinkStyles);
     });


### PR DESCRIPTION
- Allow `this.props.style` to override all other styles
- Add a `.container` wrapper of the content, so the dox can adjust its styles to match the layout/container of the page

/cc @kylecesmat 