### PR TITLE
Add classname to target logo styles

### DIFF
--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -127,6 +127,7 @@ class Footer extends React.Component {
         >
           {this.props.children}
           <div
+            className="formidableFooter-logo"
             style={{
               height: "50px",
               margin: "0 0 0 auto",

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -116,9 +116,10 @@ class Header extends React.Component {
           ]}
         >
           <div
+            className="formidableHeader-logo"
             style={{
               height: "50px",
-              marginRight: "auto",
+              margin: "0 auto 0 0",
               overflow: "hidden"
             }}
           >


### PR DESCRIPTION
- Add a logo class to target the styles—particularly useful for centering both logo and links with media queries 
- Change `marginRight` to `margin` in the header so it matchs the API in footer