### PR TITLE
Do not show scrollbars by default

### DIFF
--- a/src/themes/victory.js
+++ b/src/themes/victory.js
@@ -314,7 +314,7 @@ export default {
     width: "100%",
     height: "100%",
     maxHeight: "340px",
-    overflow: "scroll"
+    overflow: "auto"
   },
   ".Interactive .playgroundPreview": {
     alignItems: "center",


### PR DESCRIPTION
Resolves https://github.com/FormidableLabs/victory-docs/issues/124

before:
![screen shot 2016-09-14 at 10 17 51 am](https://cloud.githubusercontent.com/assets/768965/18522340/85ac4224-7a64-11e6-8e1a-c2b2a03b370e.png)


after:
![screen shot 2016-09-14 at 10 17 21 am](https://cloud.githubusercontent.com/assets/768965/18522322/72c4e454-7a64-11e6-9c3e-a83bac2a8434.png)

thanks to the simple brilliance of @bmathews 