### PR TITLE
Switch to smaller bg file for narrow screens

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1,7 +1,7 @@
 /*global document:false*/
 import React from "react";
 import ReactDOM from "react-dom";
-import Radium from "radium";
+import Radium, { StyleRoot } from "radium";
 require("normalize.css");
 
 import { Header, Footer } from "../src/index";
@@ -46,34 +46,41 @@ class Demo extends React.Component {
       />;
 
     return (
-      <div style={styles.demo}>
-        <Header
-          theme="dark"
-          logoProject={projectTextLogo}
-          padding="60px"
-          styleBy={{ textIndent: "2px" }}
-          styleContainer={{ margin: "0 auto", maxWidth: "640px" }}
-        />
-        <Header
-          theme="dark"
-          logoProject={projectSVGLogo}
-          style={{ background: "#c43a31" }}
-          styleBy={{ textIndent: "12px", color: "#fff" }}
-        >
-          <div className="default"> {/* This default class will match the Formidable branding */}
-            <a href="#about">About</a>
-            <a href="#">Docs</a>
-            <a href="#">Issues</a>
-            <a href="#">Github</a>
-          </div>
-        </Header>
-        <main style={{flex: 1}}>
-          <h1>Project X</h1>
-          <p>Content</p>
-        </main>
-        <Footer theme="light" />
-        <Footer theme="light" trademark={trademark} />
-      </div>
+      <StyleRoot>
+        <div style={styles.demo}>
+          <Header
+            theme="dark"
+            logoProject={projectTextLogo}
+            padding="60px"
+            styleBy={{ textIndent: "2px" }}
+            styleContainer={{ margin: "0 auto", maxWidth: "640px" }}
+          />
+          <Header
+            theme="dark"
+            logoProject={projectSVGLogo}
+            style={{
+              background: "#c43a31",
+              "@media only screen and (min-width: 800px)": {
+                background: "#cd5244"
+              }
+            }}
+            styleBy={{ textIndent: "12px", color: "#fff" }}
+          >
+            <div className="default"> {/* This default class will match the Formidable branding */}
+              <a href="#about">About</a>
+              <a href="#">Docs</a>
+              <a href="#">Issues</a>
+              <a href="#">Github</a>
+            </div>
+          </Header>
+          <main style={{flex: 1}}>
+            <h1>Project X</h1>
+            <p>Content</p>
+          </main>
+          <Footer theme="light" />
+          <Footer theme="light" trademark={trademark} />
+        </div>
+      </StyleRoot>
     );
   }
 }

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -5,9 +5,13 @@ import { merge } from "lodash";
 // Asset
 import LOGO_OSS from "../assets/logo-oss.svg";
 import BG from "../assets/bg.jpg";
+import BG_SM from "../assets/bg_sm.jpg";
 
 class Header extends React.Component {
   getStyles() {
+    const styleBg = this.props.style && this.props.style.background ?
+      this.props.style.background :
+      `linear-gradient(to bottom, rgba(10,9,9,0) 85%, rgba(10,9,9,0.75) 100%), #242121 url(${BG}) center right repeat`; //eslint-disable-line max-len
     return {
       base: {
         margin: 0
@@ -27,8 +31,12 @@ class Header extends React.Component {
       },
       dark: {
         // Dark Theme
-        background: `linear-gradient(to bottom, rgba(10,9,9,0) 85%, rgba(10,9,9,0.75) 100%), #242121 url(${BG}) center right repeat`, //eslint-disable-line
-        color: "#898685"
+        background: `linear-gradient(to bottom, rgba(10,9,9,0) 85%, rgba(10,9,9,0.75) 100%),
+          #242121 url(${BG_SM}) center right repeat`,
+        color: "#898685",
+        "@media only screen and (min-width: 800px)": {
+          background: styleBg
+        }
       },
       light: {
         // Light Theme


### PR DESCRIPTION
This PR swaps out the large background image for a smaller background image for narrow screen widths. 

This assumes `<StyleRoot>` exists for all apps, which means this will need to be updated when the switch to css happens. Is this still worth adding in for now? 

/cc @ebrillhart @bmathews @chrisbolin 
