### PR TITLE
Fix extra spacing above header on Formidable.com

### DIFF
--- a/demo/demo.css
+++ b/demo/demo.css
@@ -20,3 +20,14 @@
 .formidableHeader.headerDemo .formidableHeader-container {
   max-width: 640px;
 }
+
+.main {
+  flex: '1 1 auto';
+  padding: '0 3vw';
+  background-color: '#fff';
+}
+
+/* mimics how formidable.com works */
+.section {
+  padding: 6em 0;
+}

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -62,9 +62,11 @@ class Demo extends React.Component {
             <a href="#">Github</a>
           </div>
         </Header>
-        <main style={{flex: '1 1 auto', padding: '0 3vw', backgroundColor: '#fff'}}>
-          <h1>Project X</h1>
-          <p>Content</p>
+        <main>
+          <div className="section">
+            <h1>Project X</h1>
+            <p>Content</p>
+          </div>
         </main>
         <Footer theme="dark" />
         <Footer theme="light" trademark={trademark} />

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -61,7 +61,7 @@ class Header extends React.Component {
             </header>
             
           ) : (
-            <div style={{marginTop: '3em'}} />
+            ""
           )
         }
       


### PR DESCRIPTION
On the lander demo, if you don't include the sub-header, the page needed extra space to make up for how the formidable.com header overlaps the content. In practice on the formidable.com page, however, the extra space is not necessary. 

I have removed the extra 3em, and added some styling on the demo to better match how the page functions without the sub-header. 

Before image:
<img width="809" alt="before" src="https://user-images.githubusercontent.com/1584489/39541093-eb48edc2-4e01-11e8-931d-418b385873ec.png">

After fix:
<img width="814" alt="after" src="https://user-images.githubusercontent.com/1584489/39541100-f06f814e-4e01-11e8-8ea6-46757edeb386.png">
