### PR TITLE
Fix resize issue with menu

### DIFF
--- a/src/partials/formidable-header.js
+++ b/src/partials/formidable-header.js
@@ -40,7 +40,7 @@ export default class Header extends Component {
 
   componentWillUnmount() {
     document.removeEventListener("keydown", this.onEscape);
-    document.removeEventListener("resize", this.onResize);
+    window.removeEventListener("resize", this.onResize);
   }
 
     /**

--- a/src/partials/formidable-header.js
+++ b/src/partials/formidable-header.js
@@ -35,12 +35,28 @@ export default class Header extends Component {
 
   componentDidMount() {
     document.addEventListener("keydown", this.onEscape);
+    window.addEventListener("resize", this.onResize);
   }
 
   componentWillUnmount() {
     document.removeEventListener("keydown", this.onEscape);
+    document.removeEventListener("resize", this.onResize);
   }
 
+    /**
+   * Close hamburger dropdown menu items when in desktop size
+   */
+  onResize = () => {
+    const mobileVersion = document.getElementsByClassName("display-mobile-only")[0];
+    const style = getComputedStyle(mobileVersion);
+    if (style.display === "none" && this.props.isOpen === true) {
+      this.props.onToggleMenu(!this.props.isOpen);
+    }
+  }
+
+  /**
+   * Closes the hamburger menu when the escape key is pressed
+   */
   onEscape = ({ keyCode }) => {
     if (this.props.isOpen === true) {
       // If pressed escape key
@@ -50,7 +66,9 @@ export default class Header extends Component {
     }
   };
 
-  // TODO: Toggle menu when pressing esc, `(e.which === 27)`
+  /**
+   * Toggles open and closed the hamburger menu when clickong on the menu button
+   */
   toggleMenu = () => {
     this.props.onToggleMenu(!this.props.isOpen);
   };

--- a/src/partials/formidable-header.js
+++ b/src/partials/formidable-header.js
@@ -67,7 +67,7 @@ export default class Header extends Component {
   };
 
   /**
-   * Toggles open and closed the hamburger menu when clickong on the menu button
+   * Toggles open and closed the hamburger menu when clicking on the menu button
    */
   toggleMenu = () => {
     this.props.onToggleMenu(!this.props.isOpen);

--- a/test/src/components/header.spec.js
+++ b/test/src/components/header.spec.js
@@ -5,7 +5,6 @@ import { mount, shallow, render } from "enzyme";
 import Header from "../../../lib/components/header";
 
 describe("Header", () => {
-
   describe("<header>", () => {
     it("accepts custom class name", () => {
       const header = shallow(<Header className="bigRed" />).find("header");
@@ -63,33 +62,36 @@ describe("Header", () => {
   });
 
   describe("closes mobile menu on resize to desktop width", () => {
-    let header = mount(<Header />);
+    let OrigWindowWidth;
     let mobileWidth = 400;
     let desktopWidth = 1400;
 
+    before(() => {
+      OrigWindowWidth = window.innerWidth;
+    }); 
+
+    after(() => {
+      window.innerWidth = OrigWindowWidth;
+    });
+
     it("resize window to mobile size", () => {  
+      let header = mount(<Header />);
       /* Force page to a width of 400px */      
       window.innerWidth = mobileWidth; 
       expect(window.innerWidth).to.equal(mobileWidth);
-    });
 
-    it("finds mobile menu button", () => {
       /* Button exists */
       expect(header.find("button").text()).to.contain("Menu");
-    });
 
-    it("opens menu by clicking on the button", () => {
+      /* click on button */
       header.find("button").simulate("click");
       expect(header.find("nav").at(1).prop("aria-hidden")).to.equal(false);
-    });
 
-    it("resize window to desktop size", () => {
       /* Force page to a width of 1400px */      
       window.innerWidth = desktopWidth;
       expect(window.innerWidth).to.equal(desktopWidth);
-    });
 
-    it("verify menu has closed", () => {
+      /* menu should have closed */
       header.find("button").simulate("click");
       expect(header.find("nav").at(1).prop("aria-hidden")).to.equal(true);
     });

--- a/test/src/components/header.spec.js
+++ b/test/src/components/header.spec.js
@@ -63,7 +63,7 @@ describe("Header", () => {
   });
 
   describe("closes mobile menu on resize to desktop width", () => {
-    const OrigWindowWidth;
+    let OrigWindowWidth;
     const mobileWidth = 400;
     const desktopWidth = 1400;
 

--- a/test/src/components/header.spec.js
+++ b/test/src/components/header.spec.js
@@ -69,7 +69,7 @@ describe("Header", () => {
 
     it("resize window to mobile size", () => {  
       /* Force page to a width of 400px */      
-      global.innerWidth = mobileWidth; 
+      window.innerWidth = mobileWidth; 
       expect(window.innerWidth).to.equal(mobileWidth);
     });
 
@@ -85,7 +85,7 @@ describe("Header", () => {
 
     it("resize window to desktop size", () => {
       /* Force page to a width of 1400px */      
-      global.innerWidth = desktopWidth;
+      window.innerWidth = desktopWidth;
       expect(window.innerWidth).to.equal(desktopWidth);
     });
 

--- a/test/src/components/header.spec.js
+++ b/test/src/components/header.spec.js
@@ -3,6 +3,7 @@ import React from "react";
 import { mount, shallow, render } from "enzyme";
 
 import Header from "../../../lib/components/header";
+import { constants } from "zlib";
 
 describe("Header", () => {
   describe("<header>", () => {
@@ -62,9 +63,9 @@ describe("Header", () => {
   });
 
   describe("closes mobile menu on resize to desktop width", () => {
-    let OrigWindowWidth;
-    let mobileWidth = 400;
-    let desktopWidth = 1400;
+    const OrigWindowWidth;
+    const mobileWidth = 400;
+    const desktopWidth = 1400;
 
     before(() => {
       OrigWindowWidth = window.innerWidth;
@@ -75,7 +76,7 @@ describe("Header", () => {
     });
 
     it("resize window to mobile size", () => {  
-      let header = mount(<Header />);
+      const header = mount(<Header />);
       /* Force page to a width of 400px */      
       window.innerWidth = mobileWidth; 
       expect(window.innerWidth).to.equal(mobileWidth);

--- a/test/src/components/header.spec.js
+++ b/test/src/components/header.spec.js
@@ -63,16 +63,15 @@ describe("Header", () => {
   });
 
   describe("closes mobile menu on resize to desktop width", () => {
-    it("resizes window to mobile size", () => {
+    let header = mount(<Header />);
+    let mobileWidth = 400;
+    let desktopWidth = 1400;
+
+    it("resize window to mobile size", () => {  
       /* Force page to a width of 400px */      
-      global.innerWidth = 400;
-      expect(window.innerWidth).to.equal(400);
+      global.innerWidth = mobileWidth; 
+      expect(window.innerWidth).to.equal(mobileWidth);
     });
-    /* Force page to a width of 400px */      
-    global.innerWidth = 400;       
-    
-    /* find header */
-    const header = mount(<Header />);
 
     it("finds mobile menu button", () => {
       /* Button exists */
@@ -84,13 +83,13 @@ describe("Header", () => {
       expect(header.find("nav").at(1).prop("aria-hidden")).to.equal(false);
     });
 
-    it("resizes window to desktop size", () => {
+    it("resize window to desktop size", () => {
       /* Force page to a width of 1400px */      
-      global.innerWidth = 1400;
-      expect(window.innerWidth).to.equal(1400);
+      global.innerWidth = desktopWidth;
+      expect(window.innerWidth).to.equal(desktopWidth);
     });
 
-    it("verifies menu has closed", () => {
+    it("verify menu has closed", () => {
       header.find("button").simulate("click");
       expect(header.find("nav").at(1).prop("aria-hidden")).to.equal(true);
     });

--- a/test/src/components/header.spec.js
+++ b/test/src/components/header.spec.js
@@ -61,4 +61,38 @@ describe("Header", () => {
       expect(header.props().className).to.contain("isLight");
     });
   });
+
+  describe("closes mobile menu on resize to desktop width", () => {
+    it("resizes window to mobile size", () => {
+      /* Force page to a width of 400px */      
+      global.innerWidth = 400;
+      expect(window.innerWidth).to.equal(400);
+    });
+    /* Force page to a width of 400px */      
+    global.innerWidth = 400;       
+    
+    /* find header */
+    const header = mount(<Header />);
+
+    it("finds mobile menu button", () => {
+      /* Button exists */
+      expect(header.find("button").text()).to.contain("Menu");
+    });
+
+    it("opens menu by clicking on the button", () => {
+      header.find("button").simulate("click");
+      expect(header.find("nav").at(1).prop("aria-hidden")).to.equal(false);
+    });
+
+    it("resizes window to desktop size", () => {
+      /* Force page to a width of 1400px */      
+      global.innerWidth = 1400;
+      expect(window.innerWidth).to.equal(1400);
+    });
+
+    it("verifies menu has closed", () => {
+      header.find("button").simulate("click");
+      expect(header.find("nav").at(1).prop("aria-hidden")).to.equal(true);
+    });
+  });
 });


### PR DESCRIPTION
Update header to close mobile sized menu when window is resized to desktop width.

closes https://github.com/FormidableLabs/formidable.com/issues/457