### PR TITLE
Move react-side-effect dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "postcss-inline-svg": "^2.2.0",
     "postcss-url": "^7.1.2",
     "react": "^15.6.1",
+    "react-side-effect": "^1.1.5",
     "rimraf": "^2.4.4"
   },
   "devDependencies": {
@@ -70,7 +71,6 @@
     "raw-loader": "^0.5.1",
     "react-addons-test-utils": "^15.1.0",
     "react-dom": "^15.1.0",
-    "react-side-effect": "^1.1.5",
     "react-test-renderer": "^15.6.1",
     "style-loader": "^0.18.2",
     "url-loader": "^0.5.7",


### PR DESCRIPTION
Move react-side-effect from a dev dependency to a dependency for use with builder scripts