### PR TITLE
Link configuration props

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ Icon
 # Windows image file caches
 ehthumbs.db
 Thumbs.db
+
+### IDE ###
+.idea/

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -50,6 +50,8 @@ class Header extends React.Component {
           onToggleMenu={this.handleToggleMenu}
           isOpen={this.state.navOpen}
           location={this.props.location}
+          linkRenderer={this.props.linkRenderer}
+          activeLink={this.props.activeLink}
         />
         {this.props.subheader ? (
           <header className={classes}>
@@ -67,8 +69,11 @@ class Header extends React.Component {
 }
 
 Header.propTypes = {
+  activeLink: PropTypes.func,
   children: PropTypes.node,
   className: PropTypes.string,
+  isActiveLink: PropTypes.func,
+  linkRenderer: PropTypes.func,
   location: PropTypes.object,
   logoProject: PropTypes.node,
   subheader: PropTypes.bool,
@@ -94,7 +99,8 @@ Header.defaultProps = {
   logoProject: "",
   theme: "dark",
   location: { pathname: "/open-source/" },
-  subheader: true
+  subheader: true,
+  activeLink: props => props.current === props.item.path
 };
 
 export default Header;

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -73,7 +73,6 @@ Header.propTypes = {
   activeLink: PropTypes.func,
   children: PropTypes.node,
   className: PropTypes.string,
-  isActiveLink: PropTypes.func,
   linkRenderer: PropTypes.func,
   location: PropTypes.object,
   logoProject: PropTypes.node,

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -52,6 +52,7 @@ class Header extends React.Component {
           location={this.props.location}
           linkRenderer={this.props.linkRenderer}
           activeLink={this.props.activeLink}
+          preventSamePathReload={this.props.preventSamePathReload}
         />
         {this.props.subheader ? (
           <header className={classes}>
@@ -76,6 +77,7 @@ Header.propTypes = {
   linkRenderer: PropTypes.func,
   location: PropTypes.object,
   logoProject: PropTypes.node,
+  preventSamePathReload: PropTypes.bool,
   subheader: PropTypes.bool,
   theme: PropTypes.oneOf(["light", "dark"])
 };
@@ -100,7 +102,8 @@ Header.defaultProps = {
   theme: "dark",
   location: { pathname: "/open-source/" },
   subheader: true,
-  activeLink: props => props.current === props.item.path
+  activeLink: props => props.current === props.item.path,
+  preventSamePathReload: true
 };
 
 export default Header;

--- a/src/partials/formidable-header.js
+++ b/src/partials/formidable-header.js
@@ -83,6 +83,15 @@ export default class Header extends Component {
     this.props.onToggleMenu(!this.props.isOpen);
   }
 
+  handleAnchorClick(e) {
+    //if (typeof window !== undefined) {
+    if (this.props.location.pathname === e.target.getAttribute("href")) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+    //}
+  }
+
   render() {
     const { isOpen } = this.props;
     return (

--- a/src/partials/formidable-header.js
+++ b/src/partials/formidable-header.js
@@ -19,13 +19,17 @@ export default class Header extends Component {
   static displayName = "Header";
 
   static propTypes = {
+    activeLink: PropTypes.func,
     isOpen: PropTypes.bool,
+    linkRenderer: PropTypes.func,
     location: PropTypes.object,
-    onToggleMenu: PropTypes.func
+    onToggleMenu: PropTypes.func,
+    preventSamePathReload: PropTypes.bool
   };
 
   static defaultProps = {
-    isOpen: false
+    isOpen: false,
+    preventSamePathReload: true
   };
 
   constructor(props) {
@@ -33,6 +37,7 @@ export default class Header extends Component {
     this.onResize = this.onResize.bind(this);
     this.onEscape = this.onEscape.bind(this);
     this.handleToggleMenu = this.handleToggleMenu.bind(this);
+    this.handleAnchorClick = this.handleAnchorClick.bind(this);
   }
 
   componentDidMount() {
@@ -75,21 +80,24 @@ export default class Header extends Component {
   }
 
   /**
+   * @param {object} e React synthetic event object
    * Toggles open and closed the hamburger menu when clicking on the menu button
-   *
+   * and prevents reload if the path selected is the same as the current path
    * @returns {void}
    */
-  handleToggleMenu() {
+  handleToggleMenu(e) {
     this.props.onToggleMenu(!this.props.isOpen);
+    this.handleAnchorClick(e);
   }
 
   handleAnchorClick(e) {
-    //if (typeof window !== undefined) {
-    if (this.props.location.pathname === e.target.getAttribute("href")) {
+    if (
+      this.props.location.pathname === e.target.getAttribute("href") &&
+      this.props.preventSamePathReload
+    ) {
       e.preventDefault();
       e.stopPropagation();
     }
-    //}
   }
 
   render() {
@@ -98,7 +106,12 @@ export default class Header extends Component {
       <div>
         <div className={`site-header isOpen-${this.props.isOpen}`}>
           {/* Site-Header: Logo */}
-          <a href="/" className="site-header__logo" title="Formidable">
+          <a
+            onClick={this.handleAnchorClick}
+            href="/"
+            className="site-header__logo"
+            title="Formidable"
+          >
             <svg
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 97 18"
@@ -117,6 +130,9 @@ export default class Header extends Component {
                   className="site-header__nav-links"
                   item={item}
                   current={this.props.location.pathname}
+                  onClick={this.handleAnchorClick}
+                  linkRenderer={this.props.linkRenderer}
+                  activeLink={this.props.activeLink}
                   key={i}
                 />
               );
@@ -148,6 +164,8 @@ export default class Header extends Component {
                     onClick={this.handleToggleMenu}
                     item={item}
                     current={this.props.location.pathname}
+                    linkRenderer={this.props.linkRenderer}
+                    activeLink={this.props.activeLink}
                     key={i}
                   />
                 </li>

--- a/src/partials/formidable-header.js
+++ b/src/partials/formidable-header.js
@@ -28,8 +28,7 @@ export default class Header extends Component {
   };
 
   static defaultProps = {
-    isOpen: false,
-    preventSamePathReload: true
+    isOpen: false
   };
 
   constructor(props) {

--- a/src/partials/nav-link.js
+++ b/src/partials/nav-link.js
@@ -4,19 +4,35 @@ import PropTypes from "prop-types";
 export default class NavLink extends Component {
   static displayName = "NavLink";
   static propTypes = {
+    Tag: PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.object]),
     className: PropTypes.string,
     current: PropTypes.string.isRequired,
+    isActive: PropTypes.bool,
     item: PropTypes.object.isRequired,
+    linkRenderer: PropTypes.func,
     onClick: PropTypes.func
   };
 
-  render() {
-    const { className, current, item, onClick } = this.props;
-    const isActive = current === item.path ? "active" : "inactive";
-    return (
+  handleLinkRenderer(props) {
+    const { className, current, item, onClick, isActive } = props;
+    const activeClass = isActive ? "active" : "inactive";
+    return this.props.linkRenderer ? (
+      this.props.linkRenderer({ ...props, isActive })
+    ) : (
       <a href={item.path} className={`${className} ${isActive}`} onClick={onClick}>
         {item.title}
       </a>
     );
+  }
+
+  render() {
+    const {
+      className,
+      current,
+      item,
+      onClick,
+      isActive = this.props.current === this.props.item.path
+    } = this.props;
+    return this.handleLinkRenderer({ ...this.props });
   }
 }

--- a/src/partials/nav-link.js
+++ b/src/partials/nav-link.js
@@ -5,34 +5,32 @@ export default class NavLink extends Component {
   static displayName = "NavLink";
   static propTypes = {
     Tag: PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.object]),
+    activeLink: PropTypes.func,
     className: PropTypes.string,
     current: PropTypes.string.isRequired,
-    isActive: PropTypes.bool,
     item: PropTypes.object.isRequired,
     linkRenderer: PropTypes.func,
     onClick: PropTypes.func
   };
 
+  constructor(props) {
+    super(props);
+    this.handleLinkRenderer = this.handleLinkRenderer.bind(this);
+  }
+
   handleLinkRenderer(props) {
-    const { className, current, item, onClick, isActive } = props;
-    const activeClass = isActive ? "active" : "inactive";
-    return this.props.linkRenderer ? (
-      this.props.linkRenderer({ ...props, isActive })
+    const { className, item, onClick, activeLink } = props;
+    const activeClass = activeLink(props) ? "active" : "inactive";
+    return props.linkRenderer ? (
+      props.linkRenderer({ ...props, activeClass })
     ) : (
-      <a href={item.path} className={`${className} ${isActive}`} onClick={onClick}>
+      <a href={item.path} className={`${className} ${activeClass}`} onClick={onClick}>
         {item.title}
       </a>
     );
   }
 
   render() {
-    const {
-      className,
-      current,
-      item,
-      onClick,
-      isActive = this.props.current === this.props.item.path
-    } = this.props;
     return this.handleLinkRenderer({ ...this.props });
   }
 }


### PR DESCRIPTION
The assumption that we will always use anchor tags with SSR is no longer true, nor do we want to assume a one-size-fits all approach for what the activeLink logic will be, so we're providing the previous hardcoding as the sensible default: ``` props => props.current === props.item.path``` while still allowing configuration. 

Additionally, by default we want to skip a full page reload when the current path is selected again, but we _also_ don't want to make that behavior impossible since that would be swapping out one set of present assumptions for another set of present assumptions, and the future remains clouded in mystery.

This is meant to meet an immediate need for the new formidable.com, in the long run exporting configurable partials and allowing for full per-project composition/configuration idiomatically with React seems more accessible than handling in the build/transpilation which will necessarily vary by build tool and build tool version.